### PR TITLE
Add a test function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,46 +18,42 @@ find_package(diagnostic_updater REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 # =========================================================
-# 2. Build SDK (Static Library)
-# =========================================================
-file(GLOB SDK_SOURCES
-    "src/sdk/src/*.cpp"
-    "src/sdk/src/hal/*.cpp"
-    "src/sdk/src/dataunpacker/*.cpp"
-    "src/sdk/src/dataunpacker/unpacker/*.cpp"
-    "src/sdk/src/arch/linux/*.cpp"
-)
+file(
+  GLOB
+  SDK_SOURCES
+  "src/sdk/src/*.cpp"
+  "src/sdk/src/hal/*.cpp"
+  "src/sdk/src/dataunpacker/*.cpp"
+  "src/sdk/src/dataunpacker/unpacker/*.cpp"
+  "src/sdk/src/arch/linux/*.cpp")
 
 add_library(rplidar_sdk STATIC ${SDK_SOURCES})
 set_target_properties(rplidar_sdk PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-target_include_directories(rplidar_sdk PUBLIC
-  src/sdk/include
-  src/sdk/src
-)
+target_include_directories(rplidar_sdk PUBLIC src/sdk/include src/sdk/src)
 
 # =========================================================
-# 3. Build Component (Shared Library)
+# 1. Build Component (Shared Library)
 # =========================================================
-# Create a shared library containing the node logic.
-# This allows the node to be loaded into a container process for zero-copy communication.
-add_library(rplidar_node_component SHARED
-  src/rplidar_node.cpp
-  src/lidar_driver_wrapper.cpp
-)
+# Create a shared library containing the node logic. This allows the node to be
+# loaded into a container process for zero-copy communication.
+add_library(rplidar_node_component SHARED src/rplidar_node.cpp
+                                          src/lidar_driver_wrapper.cpp)
 
-target_include_directories(rplidar_node_component PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
+target_include_directories(
+  rplidar_node_component
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
 
 # Link against the RPLIDAR SDK
 target_link_libraries(rplidar_node_component rplidar_sdk)
 
 # Link ROS 2 dependencies
-ament_target_dependencies(rplidar_node_component
+ament_target_dependencies(
+  rplidar_node_component
   rclcpp
   rclcpp_components
   rclcpp_lifecycle
@@ -66,48 +62,64 @@ ament_target_dependencies(rplidar_node_component
   diagnostic_updater
   tf2
   tf2_ros
-  geometry_msgs
-)
+  geometry_msgs)
 
 # Register the component to make it discoverable by rclcpp_components
 rclcpp_components_register_nodes(rplidar_node_component "RPlidarNode")
 
 # =========================================================
-# 4. Build Standalone Executable
+# 1. Build Standalone Executable
 # =========================================================
 # Create an executable wrapper for standalone usage (e.g., 'ros2 run ...').
 add_executable(rplidar_node src/standalone_main.cpp)
 
 # Link against the component library to avoid code duplication
 target_link_libraries(rplidar_node rplidar_node_component)
-ament_target_dependencies(rplidar_node rclcpp rclcpp_lifecycle rclcpp_components)
+ament_target_dependencies(rplidar_node rclcpp rclcpp_lifecycle
+                          rclcpp_components)
 
 # =========================================================
-# 5. Install Rules
+# 1. Install Rules
 # =========================================================
 # Install the shared library (Component)
-install(TARGETS rplidar_node_component
+install(
+  TARGETS rplidar_node_component
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
+  RUNTIME DESTINATION bin)
 
 # Install the executable
-install(TARGETS rplidar_node
-  DESTINATION lib/${PROJECT_NAME}
-)
+install(TARGETS rplidar_node DESTINATION lib/${PROJECT_NAME})
 
 # Install headers
-install(DIRECTORY include/
-  DESTINATION include/${PROJECT_NAME}
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 # Install launch files, parameters, and configurations
-install(DIRECTORY
-  launch
-  param
-  config
-  DESTINATION share/${PROJECT_NAME}
-)
+install(DIRECTORY launch param config DESTINATION share/${PROJECT_NAME})
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
 
+  # Linting Tests (skipped in this phase)
+  list(
+    APPEND
+    AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_copyright
+    ament_cmake_cpplint
+    ament_cmake_uncrustify
+    ament_cmake_flake8
+    ament_cmake_pep257)
+  ament_lint_auto_find_test_dependencies()
+
+  #Google Test (Unit Test) Setup
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_rplidar_wrapper test/test_rplidar_wrapper.cpp)
+  target_include_directories(test_rplidar_wrapper PUBLIC include)
+
+  ament_add_gtest(test_rplidar_node test/test_rplidar_node.cpp)
+  target_include_directories(test_rplidar_node PUBLIC include)
+  target_link_libraries(test_rplidar_wrapper rplidar_node_component)
+  target_link_libraries(test_rplidar_node rplidar_node_component)
+  ament_target_dependencies(test_rplidar_wrapper rclcpp tf2 tf2_ros tf2_geometry_msgs)
+endif()
 ament_package()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # 🛡️ Robust RPLIDAR ROS 2 Driver (Industrial-Grade)
 
+> [!CAUTION]
+> **BETA VERSION**
+> Please use with caution in production environments. Issues and PRs are highly welcome!
+
 [![ROS2 Jazzy](https://img.shields.io/badge/ROS2-Jazzy-orange.svg?style=flat-square&logo=ros)](https://docs.ros.org/en/jazzy/)
 [![C++17](https://img.shields.io/badge/C++-17-blue.svg?style=flat-square&logo=c%2B%2B)](https://isocpp.org/)
 [![License](https://img.shields.io/badge/License-BSD--2--Clause-green.svg?style=flat-square)](https://opensource.org/licenses/BSD-2-Clause)

--- a/doc/dummy_driver_state.md
+++ b/doc/dummy_driver_state.md
@@ -1,0 +1,36 @@
+
+```mermaid
+stateDiagram-v2
+    direction LR
+
+    %% state definition
+    state "Disconnected" as OFF
+    state "Connected (Idle)" as IDLE
+    state "Scanning (Active)" as RUN
+
+    %% 1. Disconnected
+    [*] --> OFF
+    note right of OFF
+        Available: connect()
+        Others: Return Error
+    end note
+
+    %% 2. Connected
+    OFF --> IDLE : connect()
+    IDLE --> OFF : disconnect()
+
+    note right of IDLE
+        Motor: Stopped
+        grab_scan: Returns False
+    end note
+
+    %% 3. Scanning
+    IDLE --> RUN : start_motor()
+    RUN --> IDLE : stop_motor()
+    RUN --> OFF : disconnect()
+
+    note right of RUN
+        Motor: Spinning
+        grab_scan: Returns Data (Sine Wave)
+    end note
+```

--- a/doc/rplidar_driver_sequence.md
+++ b/doc/rplidar_driver_sequence.md
@@ -1,0 +1,44 @@
+
+```mermaid
+sequenceDiagram
+    participant Node as ROS2 Node (RPLidarNode)
+    participant Driver as Wrapper (LidarDriverInterface)
+    participant SDK as Slamtec SDK / Hardware
+
+    Note over Node: 1. on_configure()
+    Node->>Driver: connect(port, baudrate)
+    activate Driver
+    Driver->>SDK: Open Serial Port (e.g. /dev/ttyUSB0)
+    SDK-->>Driver: Success (Port Opened)
+    Driver->>SDK: Get Device Info (Check FW/Model)
+    SDK-->>Driver: Device Info (e.g. A1, S2)
+    Driver-->>Node: return true
+    deactivate Driver
+
+    Note over Node: 2. on_activate()
+    Node->>Driver: start_motor()
+    activate Driver
+    Driver->>SDK: Send PWM / Start Command
+    SDK-->>Driver: Success (Motor Spinning)
+    Driver-->>Node: return true
+    deactivate Driver
+
+    Note over Node: 3. Timer Loop (Running)
+    loop
+        Node->>Driver: grab_scan_data()
+        activate Driver
+        Driver->>SDK: Fetch Cached Data points
+        SDK-->>Driver: Raw Points (Distance, Angle)
+        Driver-->>Node: Vector<Points>
+        deactivate Driver
+        Node->>Node: Publish LaserScan msg
+    end
+
+    Note over Node: 4. on_deactivate()
+    Node->>Driver: stop_motor()
+    Driver->>SDK: Send Stop Command
+
+    Note over Node: 5. on_cleanup()
+    Node->>Driver: disconnect()
+    Driver->>SDK: Close Serial Port
+```

--- a/include/lidar_driver_wrapper.hpp
+++ b/include/lidar_driver_wrapper.hpp
@@ -383,6 +383,20 @@ private:
  *  - Provide deterministic or synthetic scan data
  *  - Simplify integration tests and continuous integration setups
  */
+
+#pragma once
+
+// Definition Mock driver states
+enum class MockDriverState {
+  DISCONNECTED, // Init
+  CONNECTED,    // Idle
+  SCANNING      // Active
+};
+
+/**
+ * @class DummyLidarDriver
+ * @brief Lightweight mock driver for simulation, testing, or CI environments.
+ */
 class DummyLidarDriver : public LidarDriverInterface {
 public:
   /// Construct a dummy driver in a disconnected state.
@@ -437,6 +451,10 @@ public:
    * @return Always true.
    */
   bool set_motor_speed(uint16_t /*rpm*/) override { return true; }
+
+private:
+  // Use Enum state
+  MockDriverState current_state_ = MockDriverState::DISCONNECTED;
 };
 
 #endif // LIDAR_DRIVER_WRAPPER_HPP

--- a/package.xml
+++ b/package.xml
@@ -26,9 +26,15 @@
   <depend>geometry_msgs</depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>lifecycle_msgs</exec_depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+  <test_depend>tf2</test_depend>
+  <test_depend>tf2_ros</test_depend>
+  <test_depend>tf2_geometry_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rplidar_ros2_driver</name>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
 
   <description>
     A modern, lifecycle-managed ROS2 driver for Slamtec RPLidar.

--- a/src/lidar_driver_wrapper.cpp
+++ b/src/lidar_driver_wrapper.cpp
@@ -411,37 +411,64 @@ void RealLidarDriver::reset() {
 }
 
 // ============================================================================
-// [Dummy Lidar Driver Implementation]
+// [Dummy Lidar Driver Implementation - Renamed Enum Version]
 // ============================================================================
 
 bool DummyLidarDriver::connect(const std::string &, sl_u32, bool) {
+  current_state_ = MockDriverState::CONNECTED;
   return true;
 }
 
-void DummyLidarDriver::disconnect() {}
+void DummyLidarDriver::disconnect() {
+  current_state_ = MockDriverState::DISCONNECTED;
+}
 
-bool DummyLidarDriver::isConnected() { return true; }
+bool DummyLidarDriver::isConnected() {
+  return current_state_ != MockDriverState::DISCONNECTED;
+}
 
-int DummyLidarDriver::getHealth() { return 0; }
+int DummyLidarDriver::getHealth() {
+  return (current_state_ != MockDriverState::DISCONNECTED) ? 0 : 2;
+}
 
-void DummyLidarDriver::reset() {}
+void DummyLidarDriver::reset() {
+  if (current_state_ == MockDriverState::SCANNING) {
+    current_state_ = MockDriverState::CONNECTED;
+  }
+}
 
-bool DummyLidarDriver::start_motor(std::string, uint16_t) { return true; }
+bool DummyLidarDriver::start_motor(std::string, uint16_t) {
+  if (current_state_ != MockDriverState::CONNECTED) {
+    return false;
+  }
 
-void DummyLidarDriver::stop_motor() {}
+  current_state_ = MockDriverState::SCANNING;
+  return true;
+}
+
+void DummyLidarDriver::stop_motor() {
+  if (current_state_ == MockDriverState::SCANNING) {
+    current_state_ = MockDriverState::CONNECTED;
+  }
+}
 
 void DummyLidarDriver::detect_and_init_strategy() {}
 
 void DummyLidarDriver::print_summary() {
-  std::cout << "[Dummy] Virtual RPLIDAR device ready." << std::endl;
+  std::cout << "[Dummy] Virtual RPLIDAR device ready (MockState-based)."
+            << std::endl;
 }
 
 float DummyLidarDriver::get_hw_max_distance() const { return 40.0f; }
 
 bool DummyLidarDriver::grab_scan_data(
     std::vector<sl_lidar_response_measurement_node_hq_t> &nodes) {
-  nodes.clear();
 
+  if (current_state_ != MockDriverState::SCANNING) {
+    return false;
+  }
+
+  nodes.clear();
   const int count = 360;
   nodes.reserve(count);
 
@@ -461,11 +488,11 @@ bool DummyLidarDriver::grab_scan_data(
         0.5f * std::sin(static_cast<float>(i) * 3.141592f / 180.0f + phase);
 
     node.dist_mm_q2 = static_cast<sl_u32>(dist_meters * 1000.0f * 4.0f);
-    node.quality = 200;
+    node.quality = 47;
 
     nodes.push_back(node);
   }
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
   return true;
 }

--- a/test/test_rplidar_node.cpp
+++ b/test/test_rplidar_node.cpp
@@ -1,0 +1,154 @@
+#include <future>
+#include <gtest/gtest.h>
+#include <lifecycle_msgs/msg/state.hpp>
+#include <lifecycle_msgs/msg/transition.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+
+#include "rplidar_node.hpp"
+
+using lifecycle_msgs::msg::State;
+using lifecycle_msgs::msg::Transition;
+
+class RplidarNodeTest : public ::testing::Test {
+protected:
+  // Initialize ROS 2 runtime once for the entire test suite
+  static void SetUpTestCase() { rclcpp::init(0, nullptr); }
+
+  // Shutdown ROS 2 runtime after tests complete
+  static void TearDownTestCase() { rclcpp::shutdown(); }
+};
+
+/**
+ * @brief [Lifecycle Verification]
+ * Tests the complete lifecycle state transitions (Configure -> Activate ->
+ * Deactivate -> Cleanup). Uses 'dummy_mode' to isolate logic from physical
+ * hardware dependencies.
+ */
+TEST_F(RplidarNodeTest, FullLifecycleTest) {
+  // ==========================================================================
+  // [Arrange] Setup the node with dummy mode enabled
+  // ==========================================================================
+  rclcpp::NodeOptions options;
+  // Enable dummy driver to simulate hardware behavior
+  options.append_parameter_override("dummy_mode", true);
+  // Set a dummy serial port (not used in dummy mode, but required for init)
+  options.append_parameter_override("serial_port", "/dev/null");
+
+  auto node = std::make_shared<RPlidarNode>(options);
+
+  // Verify initial state
+  EXPECT_EQ(node->get_current_state().id(), State::PRIMARY_STATE_UNCONFIGURED);
+
+  // ==========================================================================
+  // [Act & Assert] 1. Unconfigured -> Inactive (Configure)
+  // ==========================================================================
+  // This triggers init_parameters() and creates the driver instance.
+  auto result_conf = node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE));
+  EXPECT_EQ(result_conf.id(), State::PRIMARY_STATE_INACTIVE)
+      << "Failed to transition from UNCONFIGURED to INACTIVE.";
+
+  // ==========================================================================
+  // [Act & Assert] 2. Inactive -> Active (Activate)
+  // ==========================================================================
+  // This starts the scan thread and enables publishers.
+  auto result_act = node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_ACTIVATE));
+  EXPECT_EQ(result_act.id(), State::PRIMARY_STATE_ACTIVE)
+      << "Failed to transition from INACTIVE to ACTIVE.";
+
+  // ==========================================================================
+  // [Act & Assert] 3. Active -> Inactive (Deactivate)
+  // ==========================================================================
+  // This stops the scan thread and disables publishers.
+  auto result_deact = node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE));
+  EXPECT_EQ(result_deact.id(), State::PRIMARY_STATE_INACTIVE)
+      << "Failed to transition from ACTIVE to INACTIVE.";
+
+  // ==========================================================================
+  // [Act & Assert] 4. Inactive -> Unconfigured (Cleanup)
+  // ==========================================================================
+  // This destroys the driver instance and releases resources.
+  auto result_clean = node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CLEANUP));
+  EXPECT_EQ(result_clean.id(), State::PRIMARY_STATE_UNCONFIGURED)
+      << "Failed to transition from INACTIVE to UNCONFIGURED.";
+}
+
+/**
+ * @brief [Integration Test] Scan Topic Publication
+ * Verifies that the node actually publishes data to the '/scan' topic
+ * when in the ACTIVE state.
+ */
+TEST_F(RplidarNodeTest, ScanPublicationCheck) {
+  // ==========================================================================
+  // [Arrange] Setup Node, QoS, and Promise/Future for async validation
+  // ==========================================================================
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("dummy_mode", true);
+  options.append_parameter_override("frame_id", "test_laser_link");
+
+  auto node = std::make_shared<RPlidarNode>(options);
+
+  // Quickly transition to ACTIVE state
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE));
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_ACTIVATE));
+
+  // Prepare a promise to signal when a message is received
+  auto promise = std::make_shared<std::promise<void>>();
+  auto future = promise->get_future();
+  bool message_received = false;
+
+  // Create a subscriber to listen for the published scan
+  auto sub = node->create_subscription<sensor_msgs::msg::LaserScan>(
+      "scan", rclcpp::SensorDataQoS(),
+      [&](sensor_msgs::msg::LaserScan::SharedPtr msg) {
+        // ----------------------------------------------------------------------
+        // [Assert] Callback Validation (Inside the Loop)
+        // ----------------------------------------------------------------------
+        message_received = true;
+
+        // Check 1: Verify frame_id matches configuration
+        EXPECT_EQ(msg->header.frame_id, "test_laser_link");
+
+        // Check 2: Ensure data payload is present
+        // Since we use the dummy driver, it should generate valid points.
+        EXPECT_GT(msg->ranges.size(), 0) << "Received scan message is empty.";
+
+        // Signal completion
+        promise->set_value();
+      });
+
+  // ==========================================================================
+  // [Act] Spin the node to process callbacks
+  // ==========================================================================
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+
+  auto start_time = std::chrono::steady_clock::now();
+  // Wait up to 3 seconds for a message
+  while (rclcpp::ok() && !message_received) {
+    executor.spin_some();
+
+    if (std::chrono::steady_clock::now() - start_time >
+        std::chrono::seconds(3)) {
+      break; // Timeout
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // ==========================================================================
+  // [Assert] Final Validation
+  // ==========================================================================
+  EXPECT_TRUE(message_received)
+      << "Timeout: Failed to receive /scan topic within 3 seconds.";
+
+  // Clean shutdown
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE));
+}

--- a/test/test_rplidar_wrapper.cpp
+++ b/test/test_rplidar_wrapper.cpp
@@ -1,0 +1,77 @@
+#include "lidar_driver_wrapper.hpp"
+#include <cmath>
+#include <gtest/gtest.h>
+#include <memory>
+#include <thread>
+#include <vector>
+
+// ============================================================================
+//  Mock Driver Test (Logic & FSM Verification)
+// ============================================================================
+class MockDriverTest : public ::testing::Test {
+protected:
+  std::unique_ptr<LidarDriverInterface> driver;
+
+  void SetUp() override { driver = std::make_unique<DummyLidarDriver>(); }
+
+  void TearDown() override {
+    if (driver && driver->isConnected()) {
+      driver->disconnect();
+    }
+  }
+};
+/**
+ * @brief [Happy Path] Verifies data acquisition logic using Mock driver.
+ * * Ensures that:
+ * 1. The driver transitions to scanning state correctly.
+ * 2. Retrieved data is not empty and contains valid sensor readings.
+ * 3. Data mimics expected behavior (not frozen/all zeros).
+ */
+TEST_F(MockDriverTest, ScanDataSanityCheck) {
+  // ==========================================================
+  // 1. Arrange: Connect to mock port and start motor
+  // ==========================================================
+  // Mock driver always returns success for connection
+  ASSERT_TRUE(driver->connect("/dev/mock_port", 115200));
+
+  // Start motor with standard mode.
+  // Expectation: Internal state changes to SCANNING.
+  ASSERT_TRUE(driver->start_motor("Standard", 600));
+
+  // ==========================================================
+  // 2. Act: Request scan data
+  // ==========================================================
+  std::vector<sl_lidar_response_measurement_node_hq_t> nodes;
+  bool grab_result = driver->grab_scan_data(nodes);
+
+  // ==========================================================
+  // 3. Assert: Validate data integrity
+  // ==========================================================
+  // Check 1: Function returned success
+  EXPECT_TRUE(grab_result) << "Driver failed to return data packet.";
+
+  // Check 2: Vector is populated
+  EXPECT_GT(nodes.size(), 0) << "Received empty data vector.";
+
+  // Check 3: Data Quality Check (Sanity)
+  // Ensures we are not receiving a "dead" signal (all zeros or frozen values)
+  bool found_nonzero = false;
+  bool variation_detected = false;
+  float first_dist = nodes[0].dist_mm_q2;
+
+  for (size_t i = 1; i < nodes.size(); ++i) {
+    if (nodes[i].dist_mm_q2 > 0)
+      found_nonzero = true;
+    if (nodes[i].dist_mm_q2 != first_dist)
+      variation_detected = true;
+  }
+
+  EXPECT_TRUE(found_nonzero) << "FAIL: All sensor data is zero (Blind Sensor).";
+  EXPECT_TRUE(variation_detected)
+      << "FAIL: All sensor data is identical (Frozen Data).";
+
+  // Cleanup: Stop motor explicitly to verify state transition
+  driver->stop_motor();
+  EXPECT_FALSE(driver->grab_scan_data(nodes))
+      << "Should not allow data grab after stop.";
+}


### PR DESCRIPTION
## 📝 Overview
- Add mock driver
- Add Gtest
- Update version and change beta

## 🛠️ Key Changes

### 1. Build System & Infrastructure
- **CMake Refactoring**: Updated `CMakeLists.txt` to support `ament_cmake_gtest`.
- **Linter Setup**: Added initial configuration for `ament_lint` (currently non-blocking for rapid iteration).

### 2. Test Implementation (Hardware-Agnostic)
- **Mock Driver (`DummyLidarDriver`)**: Implemented a virtual driver interface to simulate connection, scanning, and disconnection events.
- **Wrapper Tests**: Added unit tests for `LidarDriverWrapper` to verify FSM transitions and data sanity (checking against "frozen" or "blind" sensor data).
- **Node Tests**: Implemented rigorous **Lifecycle State Transition** tests (Configure → Activate → Deactivate → Cleanup) using the AAA (Arrange-Act-Assert) pattern.

### 3. Documentation
- **Beta Notice**: Updated `README.md` with a `[!CAUTION]` block to reflect the current Beta status.
- **Architecture**: Added driver state descriptions.

This PR and commit is 
Generated-by: Google gemini v3.0