### PR TITLE
fix: release driver_mutex before sleep in scan mode switch

### DIFF
--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -781,7 +781,7 @@ void RPlidarNode::publish_scan(
 
 rcl_interfaces::msg::SetParametersResult RPlidarNode::parameters_callback(
     const std::vector<rclcpp::Parameter> &parameters) {
-  std::lock_guard<std::mutex> lock(driver_mutex_);
+  std::unique_lock<std::mutex> lock(driver_mutex_);
 
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;
@@ -876,7 +876,9 @@ rcl_interfaces::msg::SetParametersResult RPlidarNode::parameters_callback(
 
       // Stop the motor before switching modes.
       driver_->stop_motor();
+      lock.unlock();
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
+      lock.lock();
 
       // Attempt restart with new mode.
       if (driver_->start_motor(new_mode, params_.rpm)) {


### PR DESCRIPTION
## Summary

- In `parameters_callback`, the `lock_guard` holding `driver_mutex_` was kept across the 500 ms `sleep_for` during a scan mode change, blocking other threads (e.g. the scan loop) for the full sleep duration.
- Changed `lock_guard` → `unique_lock` on `driver_mutex_` in `parameters_callback` (line 784) to allow manual control.
- Added `lock.unlock()` before the sleep and `lock.lock()` after, so the mutex is only held while actively accessing the driver.

## Test plan

- [ ] Trigger a `scan_mode` parameter change at runtime and verify the scan loop is not stalled for 500 ms during the switch.
- [ ] Confirm no data races: `driver_` is not accessed between `unlock()` and `lock.lock()`.
- [ ] Run existing test suite to confirm no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)