### PR TITLE
Rename package to rplidar_driver

### DIFF
--- a/.github/workflows/ros2_ci.yaml
+++ b/.github/workflows/ros2_ci.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: ros-tooling/action-ros-ci@v0.3
         with:
           target-ros2-distro: ${{ matrix.ros_distribution }}
-          package-name: rplidar_ros2_driver
+          package-name: rplidar_driver
           vcs-repo-file-url: ""
           colcon-defaults: |
             {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(rplidar_ros2_driver)
+project(rplidar_driver)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Please open an issue with the title `[Experiment] Your_Robot_Name` and include:
 2. **Recovery Log:** (Copy paste the terminal output when you unplug/replug)
 3. **Screenshot:** `rqt_graph` or `rviz2`
 
-👉 [**Submit your Experiment Report Here**](https://github.com/frozenreboot/rplidar_ros2_driver/issues/new)
+👉 [**Submit your Experiment Report Here**](https://github.com/frozenreboot/rplidar_driver/issues/new)
 
 ---
 
@@ -48,7 +48,7 @@ Please open an issue with the title `[Experiment] Your_Robot_Name` and include:
 ### 1. Installation
 ```bash
 cd ~/ros2_ws/src
-git clone https://github.com/frozenreboot/rplidar_ros2_driver.git
+git clone https://github.com/frozenreboot/rplidar_driver.git
 cd ..
 
 # Install dependencies
@@ -64,7 +64,7 @@ colcon build --symlink-install
 
 
 ```Bash
-ros2 launch rplidar_ros2_driver rplidar.launch.py serial_port:=/dev/ttyUSB0
+ros2 launch rplidar_driver rplidar.launch.py serial_port:=/dev/ttyUSB0
 ```
 
 ### 3. Dynamic Reconfigure (Runtime)

--- a/launch/composition.launch.py
+++ b/launch/composition.launch.py
@@ -58,7 +58,7 @@ from launch.substitutions import LaunchConfiguration
 
 
 def generate_launch_description():
-    share_dir = get_package_share_directory("rplidar_ros2_driver")
+    share_dir = get_package_share_directory("rplidar_driver")
     params_file = os.path.join(share_dir, "param", "rplidar.yaml")
 
     namespace_arg = DeclareLaunchArgument(
@@ -107,7 +107,7 @@ def generate_launch_description():
     container_name_full = [namespace, "/", container_name]
 
     rplidar_component = ComposableNode(
-        package="rplidar_ros2_driver",
+        package="rplidar_driver",
         plugin="RPlidarNode",  # name of macro-registered c++
         name=component_name,
         namespace=namespace,

--- a/launch/debug_rviz.launch.py
+++ b/launch/debug_rviz.launch.py
@@ -16,7 +16,7 @@ def generate_launch_description():
     # Define variables
     robot_id = LaunchConfiguration("robot_id")
     rviz_config_path = PathJoinSubstitution(
-        [FindPackageShare("rplidar_ros2_driver"), "config", "debug.rviz"]
+        [FindPackageShare("rplidar_driver"), "config", "debug.rviz"]
     )
 
     # Define RViz node

--- a/launch/rplidar.launch.py
+++ b/launch/rplidar.launch.py
@@ -79,7 +79,7 @@ def generate_launch_description() -> LaunchDescription:
       - qos_reliability : Reliability QoS policy for the LaserScan publisher
                           (e.g., 'best_effort' or 'reliable')
     """
-    share_dir = get_package_share_directory("rplidar_ros2_driver")
+    share_dir = get_package_share_directory("rplidar_driver")
     node_name = "rplidar_node"
     # -------------------------------------------------------------------------
     # 1. Launch Arguments
@@ -96,7 +96,7 @@ def generate_launch_description() -> LaunchDescription:
     # 2. Lifecycle Node Definition
     # -------------------------------------------------------------------------
     driver_node = LifecycleNode(
-        package="rplidar_ros2_driver",
+        package="rplidar_driver",
         executable="rplidar_node",
         name=node_name,
         namespace="",

--- a/launch/rplidar_with_args.launch.py
+++ b/launch/rplidar_with_args.launch.py
@@ -179,7 +179,7 @@ def generate_launch_description() -> LaunchDescription:
     # 2. Lifecycle Node Definition
     # -------------------------------------------------------------------------
     driver_node = LifecycleNode(
-        package="rplidar_ros2_driver",
+        package="rplidar_driver",
         executable="rplidar_node",
         name=LaunchConfiguration("node_name"),
         namespace=LaunchConfiguration("namespace"),

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>rplidar_ros2_driver</name>
+  <name>rplidar_driver</name>
   <version>1.3.1</version>
 
   <description>

--- a/param/rplidar.yaml
+++ b/param/rplidar.yaml
@@ -1,5 +1,5 @@
 # RPLIDAR ROS2 DRIVER
-# Part of the rplidar_ros2_driver package. See LICENSE file for details.
+# Part of the rplidar_driver package. See LICENSE file for details.
 
 rplidar_node:
   ros__parameters:


### PR DESCRIPTION
## Summary

* Rename the package from `rplidar_ros2_driver` to `rplidar_driver`
* Update package metadata, CMake project name, launch files, CI config, and README usage
* Update repository links in the README to use `frozenreboot/rplidar_driver`
* Prepare the package naming for the first ROS release

## Validation

* [x] `colcon build --symlink-install --packages-select rplidar_driver --event-handlers console_direct+`
* [x] `colcon test --packages-select rplidar_driver --event-handlers console_direct+`
* [x] `colcon test-result --verbose`
* [x] `ros2 pkg prefix rplidar_driver`
* [x] `ros2 pkg executables rplidar_driver`
* [x] `ros2 pkg prefix rplidar_ros2_driver` fails as expected
* [x] `ros2 launch rplidar_driver rplidar.launch.py --show-args`
* [x] `ros2 launch rplidar_driver rplidar_with_args.launch.py --show-args`
* [x] `ros2 launch rplidar_driver composition.launch.py --show-args`
* [x] `ros2 launch rplidar_driver debug_rviz.launch.py --show-args`


**After this PR is merged, the GitHub repository will be renamed from `rplidar_ros2_driver` to `rplidar_driver` to match the new package name.**