### PR TITLE
Fix Rolling build compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,20 +49,21 @@ target_include_directories(
     $<INSTALL_INTERFACE:include>)
 
 # Link against the RPLIDAR SDK
-target_link_libraries(rplidar_node_component rplidar_sdk)
+target_link_libraries(rplidar_node_component PUBLIC rplidar_sdk)
 
 # Link ROS 2 dependencies
-ament_target_dependencies(
+target_link_libraries(
   rplidar_node_component
-  rclcpp
-  rclcpp_components
-  rclcpp_lifecycle
-  sensor_msgs
-  std_srvs
-  diagnostic_updater
-  tf2
-  tf2_ros
-  geometry_msgs)
+  PUBLIC
+    rclcpp::rclcpp
+    rclcpp_components::component
+    rclcpp_lifecycle::rclcpp_lifecycle
+    ${sensor_msgs_TARGETS}
+    ${std_srvs_TARGETS}
+    diagnostic_updater::diagnostic_updater
+    tf2::tf2
+    tf2_ros::tf2_ros
+    ${geometry_msgs_TARGETS})
 
 # Register the component to make it discoverable by rclcpp_components
 rclcpp_components_register_nodes(rplidar_node_component "RPlidarNode")
@@ -74,9 +75,7 @@ rclcpp_components_register_nodes(rplidar_node_component "RPlidarNode")
 add_executable(rplidar_node src/standalone_main.cpp)
 
 # Link against the component library to avoid code duplication
-target_link_libraries(rplidar_node rplidar_node_component)
-ament_target_dependencies(rplidar_node rclcpp rclcpp_lifecycle
-                          rclcpp_components)
+target_link_libraries(rplidar_node PRIVATE rplidar_node_component)
 
 # =========================================================
 # 1. Install Rules
@@ -115,11 +114,16 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_rplidar_wrapper test/test_rplidar_wrapper.cpp)
   target_include_directories(test_rplidar_wrapper PUBLIC include)
+  target_link_libraries(
+    test_rplidar_wrapper
+    rplidar_node_component
+    rclcpp::rclcpp
+    tf2::tf2
+    tf2_ros::tf2_ros
+    ${tf2_geometry_msgs_TARGETS})
 
   ament_add_gtest(test_rplidar_node test/test_rplidar_node.cpp)
   target_include_directories(test_rplidar_node PUBLIC include)
-  target_link_libraries(test_rplidar_wrapper rplidar_node_component)
   target_link_libraries(test_rplidar_node rplidar_node_component)
-  ament_target_dependencies(test_rplidar_wrapper rclcpp tf2 tf2_ros tf2_geometry_msgs)
 endif()
 ament_package()

--- a/include/rplidar_node.hpp
+++ b/include/rplidar_node.hpp
@@ -55,8 +55,20 @@
 #ifndef RPLIDAR_NODE_HPP_
 #define RPLIDAR_NODE_HPP_
 
+#if __has_include(<tf2/LinearMath/Quaternion.hpp>)
+#include <tf2/LinearMath/Quaternion.hpp>
+#elif __has_include(<tf2/LinearMath/Quaternion.h>)
 #include <tf2/LinearMath/Quaternion.h>
+#else
+#error "No tf2 Quaternion header found"
+#endif
+#if __has_include(<tf2_ros/static_transform_broadcaster.hpp>)
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#elif __has_include(<tf2_ros/static_transform_broadcaster.h>)
 #include <tf2_ros/static_transform_broadcaster.h>
+#else
+#error "No tf2_ros static_transform_broadcaster header found"
+#endif
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
## Summary

This PR fixes ROS 2 Rolling build compatibility while keeping Jazzy compatibility.

Changes include:

* Replace legacy `ament_target_dependencies()` usage with explicit CMake target linking where needed.
* Keep test target linking compatible with `ament_add_gtest()` to avoid mixed `target_link_libraries()` signatures.
* Add compatibility handling for updated `tf2` / `tf2_ros` header names.
* Preserve fallback support for older header names used by existing supported distros.

## Motivation

While checking Rolling compatibility for the first rosdistro release preparation, the package failed to build in the tested Rolling environment.

The issues were related to newer ROS 2 / CMake behavior:

* `ament_target_dependencies()` was not available in the tested Rolling setup.
* Legacy tf2 header includes such as `Quaternion.h` were no longer available.
* Some tf2_ros headers emitted deprecation warnings.
* Modernizing dependency linking exposed CMake plain/keyword `target_link_libraries()` signature conflicts.

This PR updates the package to use more explicit modern CMake dependency wiring and compatible tf2 header selection.

## Validation

Jazzy:

* `colcon build --symlink-install --packages-select rplidar_driver --event-handlers console_direct+`
* `colcon test --packages-select rplidar_driver --event-handlers console_direct+`
* Result: build passed, 100% tests passed

Rolling:

* `colcon build --symlink-install --packages-select rplidar_driver --event-handlers console_direct+`
* `colcon test --packages-select rplidar_driver --event-handlers console_direct+`
* Result: build passed, 100% tests passed

## Notes

* The Rolling container reported that Rolling has migrated to Ubuntu 26.04, so the current Rolling result should be treated as validation in the tested Rolling/Noble environment.
* The `cppcheck` test target passed, but cppcheck itself reported that version 2.13.0 has known performance issues and therefore did not run full analysis.
* No hardware validation was performed as part of this PR.

## References

* [Best Practices for Replacing `ament_target_dependencies` in Kilted While Maintaining Compatibility](https://discourse.openrobotics.org/t/best-practices-for-replacing-ament-target-dependencies-in-kilted-while-maintaining-compatibility/43938)

This PR follows the general direction discussed there: replacing legacy `ament_target_dependencies()` usage with explicit `target_link_libraries()` calls using modern CMake targets where practical.

## AI-assisted development disclosure
Generated-by: OpenAI ChatGPT (GPT-5.5 Thinking)