### PR TITLE
fix: Package dependency issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(diagnostic_updater REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
 
 # =========================================================
 file(
@@ -60,7 +61,8 @@ target_link_libraries(
     diagnostic_updater::diagnostic_updater
     tf2::tf2
     tf2_ros::tf2_ros
-    ${geometry_msgs_TARGETS})
+    ${geometry_msgs_TARGETS}
+    ${lifecycle_msgs_TARGETS})
 
 # Register the component to make it discoverable by rclcpp_components
 rclcpp_components_register_nodes(rplidar_node_component "RPlidarNode")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -58,7 +57,6 @@ target_link_libraries(
     rclcpp_components::component
     rclcpp_lifecycle::rclcpp_lifecycle
     ${sensor_msgs_TARGETS}
-    ${std_srvs_TARGETS}
     diagnostic_updater::diagnostic_updater
     tf2::tf2
     tf2_ros::tf2_ros

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,11 +89,9 @@ install(
 # Install the executable
 install(TARGETS rplidar_node DESTINATION lib/${PROJECT_NAME})
 
-# Install headers
-install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
-
 # Install launch files, parameters, and configurations
 install(DIRECTORY launch param config DESTINATION share/${PROJECT_NAME})
+
 if(BUILD_TESTING)
   # Linting Tests
   find_package(ament_lint_auto REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(diagnostic_updater REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
 
 # =========================================================
 file(
@@ -96,21 +95,13 @@ install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 # Install launch files, parameters, and configurations
 install(DIRECTORY launch param config DESTINATION share/${PROJECT_NAME})
 if(BUILD_TESTING)
+  # Linting Tests
   find_package(ament_lint_auto REQUIRED)
-
-  # Linting Tests (skipped in this phase)
-  list(
-    APPEND
-    AMENT_LINT_AUTO_EXCLUDE
-    ament_cmake_copyright
-    ament_cmake_cpplint
-    ament_cmake_uncrustify
-    ament_cmake_flake8
-    ament_cmake_pep257)
   ament_lint_auto_find_test_dependencies()
 
   #Google Test (Unit Test) Setup
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(tf2_geometry_msgs REQUIRED)
 
   ament_add_gtest(test_rplidar_wrapper test/test_rplidar_wrapper.cpp)
   target_include_directories(test_rplidar_wrapper PUBLIC include)
@@ -120,7 +111,7 @@ if(BUILD_TESTING)
     rclcpp::rclcpp
     tf2::tf2
     tf2_ros::tf2_ros
-    ${tf2_geometry_msgs_TARGETS})
+    tf2_geometry_msgs::tf2_geometry_msgs)
 
   ament_add_gtest(test_rplidar_node test/test_rplidar_node.cpp)
   target_include_directories(test_rplidar_node PUBLIC include)

--- a/package.xml
+++ b/package.xml
@@ -26,9 +26,9 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>geometry_msgs</depend>
+  <depend>lifecycle_msgs</depend>
 
   <exec_depend>launch_ros</exec_depend>
-  <exec_depend>lifecycle_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,6 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
-  <depend>std_srvs</depend>
   <depend>diagnostic_updater</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/package.xml
+++ b/package.xml
@@ -26,16 +26,15 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>geometry_msgs</depend>
+
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>lifecycle_msgs</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>launch_testing</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
-  <test_depend>launch_testing_ros</test_depend>
-  <test_depend>tf2</test_depend>
-  <test_depend>tf2_ros</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>tf2_geometry_msgs</test_depend>
 
   <export>


### PR DESCRIPTION
Small fixes and improvements to `package.xml` and `CMakeLists.txt` dependency declarations:
* Move `find_package(tf2_geometry_msgs)` to the BUILD_TESTING block (fixes fail in ROS buildfarm)
* Instead of adding common linters and excluding most of them, explicitly add linters we want to use in package.xml
* Change `$(tf2_geometry_msgs_TARGETS}` to `tf2_geometry_msgs::tf2_geometry_msgs`. Even though the package has `_msgs` suffix, it does not define any interfaces, it's just a normal library.
* Remove launch_testing dependencies as they're not used, and tf2 dependencies that are already covered by `<depend>` tags
* Skip header installation - they can't be used by other projects without rplidar_sdk headers either way
* Remove `std_srvs` dependency as it's not used anywhere
* `find_package` and link agaisnt `lifecycle_msgs` - The source file includes the header from this package 