### PR TITLE
build: Raise minimum CMake version to 3.8 -> 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(rplidar_driver)
 
 if(NOT CMAKE_CXX_STANDARD)


### PR DESCRIPTION
CMake 4.x (shipped with Ubuntu 26.04 / ROS 2 Lyrical) warns that compatibility with CMake < 3.10 will be removed. Verified clean builds on both Jazzy (CMake 3.28) and Lyrical (GCC 15.2).