### PR TITLE
docs: Prepare for 1.4.0 release

### DIFF
--- a/.github/workflows/ros2_ci.yaml
+++ b/.github/workflows/ros2_ci.yaml
@@ -21,15 +21,19 @@ jobs:
           # Humble Ubuntu 22.04 (Jammy)
           - ros_distribution: humble
             docker_image: osrf/ros:humble-desktop
+            use_ros2_testing: false
           # Jazzy Ubuntu 24.04 (Noble)
           - ros_distribution: jazzy
             docker_image: osrf/ros:jazzy-desktop
+            use_ros2_testing: false
           # Lyrical Ubuntu 26.04 (Resolute)
           - ros_distribution: lyrical
             docker_image: osrf/ros:lyrical-desktop
-          # Rolling (latest supported Ubuntu)
+            use_ros2_testing: false
+          # Rolling (uses the ros2-testing apt repository)
           - ros_distribution: rolling
             docker_image: osrf/ros:rolling-desktop
+            use_ros2_testing: true
 
     container:
       image: ${{ matrix.docker_image }}
@@ -42,9 +46,10 @@ jobs:
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
+          use-ros2-testing: ${{ matrix.use_ros2_testing }}
 
       - name: Build and Test
-        uses: ros-tooling/action-ros-ci@v0.3
+        uses: ros-tooling/action-ros-ci@v0.4
         with:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           package-name: rplidar_driver

--- a/.github/workflows/ros2_ci.yaml
+++ b/.github/workflows/ros2_ci.yaml
@@ -15,6 +15,8 @@ jobs:
         ros_distribution:
           - humble
           - jazzy
+          - lyrical
+          - rolling
         include:
           # Humble Ubuntu 22.04 (Jammy)
           - ros_distribution: humble
@@ -22,6 +24,12 @@ jobs:
           # Jazzy Ubuntu 24.04 (Noble)
           - ros_distribution: jazzy
             docker_image: osrf/ros:jazzy-desktop
+          # Lyrical Ubuntu 26.04 (Resolute)
+          - ros_distribution: lyrical
+            docker_image: osrf/ros:lyrical-desktop
+          # Rolling (latest supported Ubuntu)
+          - ros_distribution: rolling
+            docker_image: osrf/ros:rolling-desktop
 
     container:
       image: ${{ matrix.docker_image }}
@@ -47,4 +55,3 @@ jobs:
                 "mixin": ["coverage-gcc"]
               }
             }
-          colcon-mixin-name: coverage-gcc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,4 @@ repos:
         entry: "[\x80-\uffff]"
         language: pygrep
         types: [text]
-        exclude: ^src/sdk/|^README\.md$
+        exclude: ^src/sdk/|^README\.md$|^CHANGELOG\.rst$|^GOVERNANCE\.md$|^package\.xml$

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,16 +4,28 @@ Changelog for package rplidar_driver
 
 Forthcoming
 -----------
-
-* Added GTest-based test infrastructure, including mock driver tests and lifecycle/publication tests.
-* Added driver state and driver sequence documentation.
-* Updated README to mark the current release status as beta and document related cautions.
-* Clarified that the angle_offset parameter is specified in radians, following `REP-103 <https://www.ros.org/reps/rep-0103.html>`_.
-* Removed the angle_offset launch argument and rely on YAML parameters instead.
-* Fixed QoS parameter inconsistency by initializing the QoS parameter and applying the configured policy.
-* Added governance documentation and maintainer information.
-* Added an AI disclosure section for OSRF compliance.
-* Contributors: frozenreboot, cosmicog
+* Raised the minimum required CMake version to 3.16 and verified builds on
+  ROS 2 Jazzy and Lyrical (`#38 <https://github.com/frozenreboot/rplidar_driver/issues/38>`_).
+* Refactored the node entry point to use the rclcpp_components template macro
+  and moved the node into the ``rplidar_node`` namespace (`#36 <https://github.com/frozenreboot/rplidar_driver/issues/36>`_).
+* Cleaned up package dependencies and linter configuration, fixing test
+  dependency failures on the ROS build farm (`#35 <https://github.com/frozenreboot/rplidar_driver/issues/35>`_).
+* Fixed Rolling build compatibility (`#33 <https://github.com/frozenreboot/rplidar_driver/issues/33>`_).
+* Added a license audit documenting the vendored Slamtec SDK provenance for
+  the first rosdistro release (`#32 <https://github.com/frozenreboot/rplidar_driver/issues/32>`_).
+* Converted the changelog to REP-132 format for catkin release tools (`#31 <https://github.com/frozenreboot/rplidar_driver/issues/31>`_).
+* Renamed the package to ``rplidar_driver`` following REP-144 naming
+  guidelines (`#29 <https://github.com/frozenreboot/rplidar_driver/issues/29>`_).
+* Added GTest-based test infrastructure, including mock driver tests and
+  lifecycle/publication tests (`#20 <https://github.com/frozenreboot/rplidar_driver/issues/20>`_).
+* Clarified that the ``angle_offset`` parameter is specified in radians and
+  removed the corresponding launch argument in favor of YAML parameters
+  (`#23 <https://github.com/frozenreboot/rplidar_driver/issues/23>`_).
+* Fixed QoS parameter inconsistency by initializing the QoS parameter and
+  applying the configured policy (`#15 <https://github.com/frozenreboot/rplidar_driver/issues/15>`_).
+* Added governance documentation and an AI disclosure section for OSRF
+  compliance; added Błażej Sowa as a maintainer (`#34 <https://github.com/frozenreboot/rplidar_driver/issues/34>`_).
+* Contributors: Błażej Sowa, JWJ | frozenreboot, cosmicog, wj
 
 v1.3.0 (2026-01-18)
 -------------------

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,11 +6,15 @@ This project is maintained by a small group of robotics engineers dedicated to o
 
 * **Woojin Jung (@frozenreboot)**
     * **Role:** Lead Maintainer / Author
-    * **Responsibilities:** Core implementation, Release management, Roadmap definition, Issue tracking.
+    * **Responsibilities:** Core implementation, Release decisions, Roadmap definition, Issue tracking.
 
 * **Orhan G. Hafif (@cosmicog)**
     * **Role:** Co-Maintainer / Technical Advisor
     * **Responsibilities:** Architecture review, Industrial use-case validation, Edge case analysis, Code review.
+
+* **Błażej Sowa (@bjsowa)**
+    * **Role:** Release Maintainer / Packaging Maintainer
+    * **Responsibilities:** rosdistro release process, bloom workflow, release repository management (ros2-gbp), packaging conventions, changelog format.
 
 ## Collaboration Protocol
 

--- a/README.md
+++ b/README.md
@@ -1,51 +1,50 @@
-# 🛡️ Robust RPLIDAR ROS 2 Driver (Industrial-Grade)
+# 🛡️ Robust RPLIDAR ROS 2 Driver
 
-> [!CAUTION]
-> **BETA VERSION**
-> Please use with caution in production environments. Issues and PRs are highly welcome!
-
-[![ROS2 Jazzy](https://img.shields.io/badge/ROS2-Jazzy-orange.svg?style=flat-square&logo=ros)](https://docs.ros.org/en/jazzy/)
+[![ROS 2 Jazzy](https://img.shields.io/badge/ROS2-Jazzy-orange.svg?style=flat-square&logo=ros)](https://docs.ros.org/en/jazzy/)
+[![ROS 2 Lyrical](https://img.shields.io/badge/ROS2-Lyrical-blueviolet.svg?style=flat-square&logo=ros)](https://docs.ros.org/en/lyrical/)
+[![ROS 2 Rolling](https://img.shields.io/badge/ROS2-Rolling-lightgrey.svg?style=flat-square&logo=ros)](https://docs.ros.org/en/rolling/)
 [![C++17](https://img.shields.io/badge/C++-17-blue.svg?style=flat-square&logo=c%2B%2B)](https://isocpp.org/)
 [![License](https://img.shields.io/badge/License-BSD--2--Clause-green.svg?style=flat-square)](https://opensource.org/licenses/BSD-2-Clause)
-[![Build Status](https://img.shields.io/badge/Build-Passing-brightgreen.svg?style=flat-square)]()
+[![ROS 2 CI](https://github.com/frozenreboot/rplidar_driver/actions/workflows/ros2_ci.yaml/badge.svg)](https://github.com/frozenreboot/rplidar_driver/actions/workflows/ros2_ci.yaml)
 
 > **"Because the official driver shouldn't crash just because you pulled the plug."**
 
-This is a heavily refactored, **fault-tolerant** ROS 2 driver for Slamtec RPLIDAR.
-Designed with a **Lifecycle State Machine** and **Thread-Safe Architecture**, ensuring your robot keeps running even under hardware disconnection or permission failures.
+A **fault-tolerant** ROS 2 driver for Slamtec RPLIDAR, built around a
+**Lifecycle State Machine** and a **thread-safe architecture**. Your robot
+keeps running even under hardware disconnection or permission failures.
 
 ---
 
-## ⚡ Why Use This? (Table of Shame)
+## ⚡ Why Use This?
 
-| Feature | Official Slamtec ROS 2 | **This Driver (frozenreboot)** |
+Most existing RPLIDAR drivers assume the hardware never misbehaves. This
+driver assumes the opposite. Compared to the reference implementation:
+
+| Capability | Reference Driver | **This Driver** |
 | :--- | :---: | :---: |
-| **Hot-plug Recovery** | ❌ Crash / Hang | **✅ Auto-reconnect via FSM** |
-| **Permission Denied** | ❌ Silent Fail / Garbage Data | **✅ Explicit Diagnostics** |
-| **Dynamic Reconfigure** | ❌ Restart Required | **✅ Runtime RPM/Mode Update** |
-| **Zero-Copy Optimization**| ❌ N/A | **✅ Smart Pointer & Move Semantics** |
-| **Architecture** | ❌ Tight SDK Coupling | **✅ Interface-based Abstraction** |
-
----
-
-## 🧪 Call for Experiments: "Does it survive?"
-
-I need your help to validate this driver on various robots!
-If you use this driver, please **stress-test** it (e.g., unplug USB while scanning, change RPM dynamically) and share your results.
-
-### 📢 How to Submit a Report
-Please open an issue with the title `[Experiment] Your_Robot_Name` and include:
-1. **Lidar Model:** (e.g., A1, A2, S1...)
-2. **Recovery Log:** (Copy paste the terminal output when you unplug/replug)
-3. **Screenshot:** `rqt_graph` or `rviz2`
-
-👉 [**Submit your Experiment Report Here**](https://github.com/frozenreboot/rplidar_driver/issues/new)
+| **Hot-plug recovery** | Not handled | ✅ Auto-reconnect via lifecycle FSM |
+| **Permission failure reporting** | Silent failure | ✅ Explicit diagnostics |
+| **Runtime reconfiguration** | Restart required | ✅ Live RPM / scan-mode update |
+| **Component composition** | Standalone only | ✅ `rclcpp_components` support |
+| **SDK coupling** | Direct calls throughout | ✅ Interface-based abstraction layer |
 
 ---
 
 ## 🚀 Getting Started
 
-### 1. Installation
+### Option A — Binary install *(coming soon)*
+
+This package has been submitted to the ROS 2 build farm. Once it syncs, you
+will be able to install it directly:
+
+```bash
+sudo apt install ros-${ROS_DISTRO}-rplidar-driver
+```
+
+Supported distros: **Jazzy**, **Lyrical**, and **Rolling**.
+
+### Option B — Build from source
+
 ```bash
 cd ~/ros2_ws/src
 git clone https://github.com/frozenreboot/rplidar_driver.git
@@ -60,23 +59,36 @@ rosdep install --from-paths src --ignore-src -r -y
 colcon build --symlink-install
 ```
 
-### 2. Quick Launch
+### Quick Launch
 
-
-```Bash
+```bash
 ros2 launch rplidar_driver rplidar.launch.py serial_port:=/dev/ttyUSB0
 ```
 
-### 3. Dynamic Reconfigure (Runtime)
+### Dynamic Reconfigure (Runtime)
 
 You can change the motor speed without killing the node:
 
-
-```Bash
-
+```bash
 ros2 param set /rplidar_node rpm 1000
 ros2 param set /rplidar_node scan_mode DenseBoost
 ```
+
+---
+
+## 🧪 Call for Experiments: "Does it survive?"
+
+We need your help to validate this driver on various robots!
+If you use this driver, please **stress-test** it (e.g., unplug USB while
+scanning, change RPM dynamically) and share your results.
+
+### 📢 How to Submit a Report
+Please open an issue with the title `[Experiment] Your_Robot_Name` and include:
+1. **Lidar Model:** (e.g., A1, A2, S1...)
+2. **Recovery Log:** (Copy paste the terminal output when you unplug/replug)
+3. **Screenshot:** `rqt_graph` or `rviz2`
+
+👉 [**Submit your Experiment Report Here**](https://github.com/frozenreboot/rplidar_driver/issues/new)
 
 ---
 
@@ -85,22 +97,18 @@ ros2 param set /rplidar_node scan_mode DenseBoost
 This driver uses a **3-Layer Design** to decouple ROS 2 logic from the vendor SDK.
 
 - **Node Layer:** Handles Lifecycle & Parameters.
-
 - **Wrapper Layer:** Handles Threading & Mutex.
-
 - **SDK Layer:** Raw data fetching.
-
 
 ![Architecture Diagram](./doc/architecture.png)
 
 ---
 
-## 👤 Author & Maintainer
+## 👥 Maintainers
 
-- **frozenreboot** - _Initial Refactoring & Architecture Design_
-
-- Blog: [Tech Log](https://frozenreboot.github.io/)
-
+- **frozenreboot** — Architecture & core development · [Tech Log](https://frozenreboot.github.io/)
+- **cosmicog** ([@cosmicog](https://github.com/cosmicog)) — Co-maintainer
+- **Błażej Sowa** ([@bjsowa](https://github.com/bjsowa)) — Release & packaging
 
 Based on the original work by RoboPeak & Slamtec.
 
@@ -108,12 +116,14 @@ Based on the original work by RoboPeak & Slamtec.
 
 ## 🤖 AI-Assisted Development Disclosure
 
-In compliance with the [OSRF Policy on the Use of Generative AI in Contributions](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) (Effective May 2025), I explicitly disclose the use of Generative AI tools in the development of this driver.
+In compliance with the [OSRF Policy on the Use of Generative AI in Contributions](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md) (Effective May 2025), we explicitly disclose the use of Generative AI tools in the development of this driver.
 
 * **Tools Used:**
-    * **Google Gemini / ChatGPT (LLMs):** Used for generating boilerplate code, formatting documentation, and initial refactoring suggestions.
+    * **Anthropic Claude:** Release engineering support, refactoring suggestions, and documentation.
+    * **Google Gemini:** Boilerplate code generation and test infrastructure scaffolding.
+    * **OpenAI ChatGPT:** Refactoring suggestions and documentation formatting.
 * **Verification:**
-    * All AI-generated content has been **manually reviewed, tested, and verified** by the maintainer.
-    * The logic, memory safety (C++17 standards), and ROS 2 lifecycle state transitions have been rigorously checked to ensure system stability.
+    * All AI-generated content has been **manually reviewed, tested, and verified** by the maintainers.
+    * The logic, memory safety, and ROS 2 lifecycle state transitions have been rigorously checked to ensure system stability.
 * **Note:**
-    * Future contributions will strictly follow the `Generated-by:` tag convention in commit messages as per the OSRF guidelines.
+    * Contributions follow the `Generated-by:` tag convention in commit messages as per the OSRF guidelines.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # 🛡️ Robust RPLIDAR ROS 2 Driver
 
+[![ROS 2 Humble](https://img.shields.io/badge/ROS2-Humble-blue.svg?style=flat-square&logo=ros)](https://docs.ros.org/en/humble/)
 [![ROS 2 Jazzy](https://img.shields.io/badge/ROS2-Jazzy-orange.svg?style=flat-square&logo=ros)](https://docs.ros.org/en/jazzy/)
 [![ROS 2 Lyrical](https://img.shields.io/badge/ROS2-Lyrical-blueviolet.svg?style=flat-square&logo=ros)](https://docs.ros.org/en/lyrical/)
 [![ROS 2 Rolling](https://img.shields.io/badge/ROS2-Rolling-lightgrey.svg?style=flat-square&logo=ros)](https://docs.ros.org/en/rolling/)
@@ -41,7 +42,7 @@ will be able to install it directly:
 sudo apt install ros-${ROS_DISTRO}-rplidar-driver
 ```
 
-Supported distros: **Jazzy**, **Lyrical**, and **Rolling**.
+Supported distros: **Humble**, **Jazzy**, **Lyrical**, and **Rolling**.
 
 ### Option B — Build from source
 


### PR DESCRIPTION
## Summary

Final documentation pass before the first rosdistro release (v1.4.0).
Part of the release preparation tracked in #28.

- Remove the beta caution and update the installation guide
  (binary install marked as "coming soon" until the first sync)
- Wire up the real CI badge (`ros2_ci.yaml`) and add Lyrical / Rolling badges
- Sync maintainer lists across README and GOVERNANCE — adds @bjsowa as
  Release / Packaging Maintainer, as agreed in #26
- Add Anthropic Claude to the AI disclosure section
- Consolidate the CHANGELOG `Forthcoming` section into user-facing 1.4.0
  release notes (removes the orphaned unreleased section)
- Exempt documentation files from the ASCII-only pre-commit hook so
  maintainer names can be spelled correctly

## Review focus

- @bjsowa: please check that your role description in GOVERNANCE.md and
  README matches what we discussed in #26
- CHANGELOG `Forthcoming` wording — this text becomes the v1.4.0 release
  notes verbatim once `catkin_prepare_release` runs
- Supported distro list (Rolling / Jazzy / Lyrical): Lyrical was verified
  today on a fresh `ros:lyrical` container (GCC 15.2, CMake 4.x) — build
  and tests pass with no source changes

## Next steps after merge

1. Run `catkin_prepare_release --bump minor` on `main`
   (1.3.1 → **1.4.0**, tags `v1.4.0`)
   - Note: I will temporarily bypass branch protection for the version
     bump commit and tag push, then re-enable it
2. Run `bloom-release` for rolling, jazzy, and lyrical
3. Track the ros/rosdistro PRs and build farm results

Updates checklist items in #28: Lyrical support ✅, release repository ✅
(ros2-gbp invitation accepted today), changelog ✅ (this PR).