### PR TITLE
fix: Pass node by reference to StaticTransformBroadcaster

### DIFF
--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -169,7 +169,7 @@ RPlidarNode::on_configure(const rclcpp_lifecycle::State &) {
   // ------------------------------------------------------------------------
   if (params_.publish_tf) {
     tf_broadcaster_ =
-        std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
+        std::make_shared<tf2_ros::StaticTransformBroadcaster>(*this);
     geometry_msgs::msg::TransformStamped t;
 
     t.header.stamp = this->now();


### PR DESCRIPTION
Rolling's tf2_ros now takes rclcpp::node_interfaces::NodeInterfaces, which converts from a node reference but not from a raw pointer. Passing *this compiles on all supported distros.

Generated-by: Anthropic Claude (Claude Fable 5)