### PR TITLE
feat: Add standby mode - LIDAR motor stops without subscribers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,22 +2,6 @@
 Changelog for package rplidar_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
-* Added a ``STANDBY`` driver state together with ``stop_motor`` and
-  ``start_motor`` services (``std_srvs/srv/Empty``), which park the motor
-  without leaving the ACTIVE lifecycle state. The serial connection, the scan
-  thread and the publishers stay alive, so waking up only costs the motor
-  spin-up time. Service names match ``rplidar_ros``.
-* Added the ``auto_standby`` parameter (default ``false``), which lets the
-  subscriber count drive the motor: the device parks itself when the last
-  consumer of the scan topic disconnects and spins up again when one appears.
-  Cloud subscribers are counted as well when ``publish_point_cloud`` is
-  enabled. While enabled, the two services are rejected, as in ``rplidar_ros``.
-* Extended the diagnostics to report standby and to distinguish an automatic
-  standby ("no subscribers") from a manually requested one.
-* Contributors: fszkudlarek
-
 1.4.1 (2026-07-18)
 ------------------
 * Fixed the Rolling build by passing the node by reference to

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog for package rplidar_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added a ``STANDBY`` driver state together with ``stop_motor`` and
+  ``start_motor`` services (``std_srvs/srv/Empty``), which park the motor
+  without leaving the ACTIVE lifecycle state. The serial connection, the scan
+  thread and the publishers stay alive, so waking up only costs the motor
+  spin-up time. Service names match ``rplidar_ros``.
+* Added the ``auto_standby`` parameter (default ``false``), which lets the
+  subscriber count drive the motor: the device parks itself when the last
+  consumer of the scan topic disconnects and spins up again when one appears.
+  Cloud subscribers are counted as well when ``publish_point_cloud`` is
+  enabled. While enabled, the two services are rejected, as in ``rplidar_ros``.
+* Extended the diagnostics to report standby and to distinguish an automatic
+  standby ("no subscribers") from a manually requested one.
+* Contributors: fszkudlarek
+
 1.4.1 (2026-07-18)
 ------------------
 * Fixed the Rolling build by passing the node by reference to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 
 # =========================================================
 file(
@@ -62,7 +63,8 @@ target_link_libraries(
     tf2::tf2
     tf2_ros::tf2_ros
     ${geometry_msgs_TARGETS}
-    ${lifecycle_msgs_TARGETS})
+    ${lifecycle_msgs_TARGETS}
+    ${std_srvs_TARGETS})
 
 # Register the component to make it discoverable by rclcpp_components
 rclcpp_components_register_node(rplidar_node_component

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ scan thread and the publishers all stay up, so waking costs only the motor
 spin-up time:
 
 ```bash
-ros2 service call /stop_motor std_srvs/srv/Empty
-ros2 service call /start_motor std_srvs/srv/Empty
+ros2 service call /stop_motor std_srvs/srv/Trigger
+ros2 service call /start_motor std_srvs/srv/Trigger
 ```
 
 Or let the driver follow demand. With `auto_standby` the motor stops while

--- a/README.md
+++ b/README.md
@@ -95,9 +95,7 @@ ros2 param set /rplidar_node auto_standby true
 ```
 
 While `auto_standby` is enabled the two services are rejected, so the
-subscriber count stays the single source of truth. Service names, the
-parameter name and this precedence all match `rplidar_ros`, so existing
-tooling keeps working.
+subscriber count stays the single source of truth.
 
 Diagnostics say *why* the motor is idle, which is usually the question:
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,36 @@ ros2 param set /rplidar_node rpm 1000
 ros2 param set /rplidar_node scan_mode DenseBoost
 ```
 
+### Standby (Motor Control)
+
+Park the motor without leaving the ACTIVE state. The serial connection, the
+scan thread and the publishers all stay up, so waking costs only the motor
+spin-up time:
+
+```bash
+ros2 service call /stop_motor std_srvs/srv/Empty
+ros2 service call /start_motor std_srvs/srv/Empty
+```
+
+Or let the driver follow demand. With `auto_standby` the motor stops while
+nobody subscribes to `scan` (or to `cloud`, when `publish_point_cloud` is
+enabled) and restarts as soon as somebody does:
+
+```bash
+ros2 param set /rplidar_node auto_standby true
+```
+
+While `auto_standby` is enabled the two services are rejected, so the
+subscriber count stays the single source of truth. Service names, the
+parameter name and this precedence all match `rplidar_ros`, so existing
+tooling keeps working.
+
+Diagnostics say *why* the motor is idle, which is usually the question:
+
+```bash
+ros2 topic echo /diagnostics    # "Standby (auto: no subscribers)" vs "Standby (motor off)"
+```
+
 ---
 
 ## 🧪 Call for Experiments: "Does it survive?"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ ros2 param set /rplidar_node auto_standby true
 While `auto_standby` is enabled the two services are rejected, so the
 subscriber count stays the single source of truth.
 
+Toggling the parameter hands the motor over, and the new owner decides from
+scratch: a pending `stop_motor` standby is dropped, and switching back off
+leaves the motor running.
+
 Diagnostics say *why* the motor is idle, which is usually the question:
 
 ```bash

--- a/doc/rplidar_driver_sequence.md
+++ b/doc/rplidar_driver_sequence.md
@@ -34,11 +34,19 @@ sequenceDiagram
         Node->>Node: Publish LaserScan msg
     end
 
-    Note over Node: 4. on_deactivate()
+    Note over Node: 4. Standby (stop_motor service or auto_standby)
+    Node->>Driver: stop_motor()
+    Driver->>SDK: Send Stop Command + Motor Speed 0
+    Note over Node,SDK: Serial port stays open, node stays ACTIVE
+    Node->>Driver: start_motor() (service call, or a subscriber appears)
+    Driver->>SDK: Restart Motor + Scan
+    Note over Node: Back to the running loop
+
+    Note over Node: 5. on_deactivate()
     Node->>Driver: stop_motor()
     Driver->>SDK: Send Stop Command
 
-    Note over Node: 5. on_cleanup()
+    Note over Node: 6. on_cleanup()
     Node->>Driver: disconnect()
     Driver->>SDK: Close Serial Port
 ```

--- a/include/rplidar_node.hpp
+++ b/include/rplidar_node.hpp
@@ -254,6 +254,16 @@ private:
   void scan_loop();
 
   /**
+   * @brief Count the subscribers the scan thread is producing data for.
+   *
+   * Includes the PointCloud2 subscribers when @c publish_point_cloud is
+   * enabled, so that a cloud-only consumer keeps the motor spinning.
+   *
+   * @return Total number of connected subscribers.
+   */
+  size_t count_output_subscribers() const;
+
+  /**
    * @brief Service callback requesting the STANDBY state (motor off).
    *
    * The request is only recorded here; the actual transition is performed by
@@ -416,6 +426,18 @@ private:
 
     // QoS policy for the publishers
     std::string qos_policy = "sensor_data";
+
+    /**
+     * @brief Automatically enter STANDBY while nobody subscribes.
+     *
+     * When enabled, the node stops the motor as soon as the last subscriber
+     * of the scan (and, if enabled, cloud) topic disconnects, and restarts it
+     * when a subscriber appears again.
+     *
+     * While this is enabled the @c stop_motor / @c start_motor services are
+     * rejected: the subscriber count is the single source of truth.
+     */
+    bool auto_standby = false;
   } params_;
 
   // ---------------------------------------------------------------------
@@ -468,8 +490,17 @@ private:
   /// share fsm state across threads
   std::atomic<DriverState> current_state_{DriverState::CONNECTING};
 
-  /// Requested standby state, consumed by @ref scan_loop() on each iteration.
+  /// Standby explicitly requested through the services, consumed by
+  /// @ref scan_loop() on each iteration.
   std::atomic<bool> standby_requested_{false};
+
+  /// Runtime-updatable mirror of @ref Parameters::auto_standby, read by the
+  /// scan thread and written by the parameter callback.
+  std::atomic<bool> auto_standby_enabled_{false};
+
+  /// True while STANDBY is held because no subscriber is connected.
+  /// Written by the scan thread, read by the diagnostics callback.
+  std::atomic<bool> auto_standby_engaged_{false};
 
   /// Mutex protecting access to the driver instance from multiple threads.
   std::mutex driver_mutex_;

--- a/include/rplidar_node.hpp
+++ b/include/rplidar_node.hpp
@@ -472,10 +472,10 @@ private:
   /// Handle for the dynamic parameter callback registration.
   OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 
-  /// Service putting the device into STANDBY (rplidar_ros compatible name).
+  /// Service putting the device into STANDBY.
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr stop_motor_service_;
 
-  /// Service leaving STANDBY (rplidar_ros compatible name).
+  /// Service leaving STANDBY.
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr start_motor_service_;
 
   /// Diagnostic updater instance used to report node and device health.

--- a/include/rplidar_node.hpp
+++ b/include/rplidar_node.hpp
@@ -85,7 +85,7 @@
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <std_srvs/srv/empty.hpp>
+#include <std_srvs/srv/trigger.hpp>
 #include <thread>
 #include <vector>
 
@@ -264,15 +264,32 @@ private:
   size_t count_output_subscribers() const;
 
   /**
+   * @brief Common guard shared by the two manual standby services.
+   *
+   * A manual request is refused when @c auto_standby owns the motor, or when
+   * the node is not ACTIVE and the scan loop that applies the request is
+   * therefore not running.
+   *
+   * @param service_name Service name, used for logging only.
+   * @param[out] response Filled in with the reason when the request is
+   *             refused; left untouched otherwise.
+   * @return true if the request was refused and the caller should return.
+   */
+  bool standby_request_refused(const char *service_name,
+                               std_srvs::srv::Trigger::Response &response);
+
+  /**
    * @brief Service callback requesting the STANDBY state (motor off).
    *
    * The request is only recorded here; the actual transition is performed by
-   * @ref scan_loop() so that the FSM stays owned by a single thread.
+   * @ref scan_loop() so that the FSM stays owned by a single thread. The
+   * response therefore reports whether the request was accepted, not whether
+   * the motor has already spun down.
    */
   void handle_stop_motor(
       const std::shared_ptr<rmw_request_id_t> request_header,
-      const std::shared_ptr<std_srvs::srv::Empty::Request> request,
-      std::shared_ptr<std_srvs::srv::Empty::Response> response);
+      const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+      std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
   /**
    * @brief Service callback leaving the STANDBY state (motor on).
@@ -281,8 +298,8 @@ private:
    */
   void handle_start_motor(
       const std::shared_ptr<rmw_request_id_t> request_header,
-      const std::shared_ptr<std_srvs::srv::Empty::Request> request,
-      std::shared_ptr<std_srvs::srv::Empty::Response> response);
+      const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+      std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
   /**
    * @brief Publish LaserScan & PointCloud2 (if enabled) messages.
@@ -473,10 +490,10 @@ private:
   OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 
   /// Service putting the device into STANDBY.
-  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr stop_motor_service_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr stop_motor_service_;
 
   /// Service leaving STANDBY.
-  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr start_motor_service_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr start_motor_service_;
 
   /// Diagnostic updater instance used to report node and device health.
   diagnostic_updater::Updater diagnostic_updater_;

--- a/include/rplidar_node.hpp
+++ b/include/rplidar_node.hpp
@@ -85,6 +85,7 @@
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <std_srvs/srv/empty.hpp>
 #include <thread>
 #include <vector>
 
@@ -92,7 +93,14 @@
 
 namespace rplidar_driver {
 
-enum class DriverState { CONNECTING, CHECK_HEALTH, WARMUP, RUNNING, RESETTING };
+enum class DriverState {
+  CONNECTING,
+  CHECK_HEALTH,
+  WARMUP,
+  RUNNING,
+  RESETTING,
+  STANDBY
+};
 /**
  * @class RPlidarNode
  * @brief Managed ROS 2 Lifecycle node for Slamtec RPLIDAR devices.
@@ -244,6 +252,27 @@ private:
    * The loop terminates when @ref is_scanning_ is set to false.
    */
   void scan_loop();
+
+  /**
+   * @brief Service callback requesting the STANDBY state (motor off).
+   *
+   * The request is only recorded here; the actual transition is performed by
+   * @ref scan_loop() so that the FSM stays owned by a single thread.
+   */
+  void handle_stop_motor(
+      const std::shared_ptr<rmw_request_id_t> request_header,
+      const std::shared_ptr<std_srvs::srv::Empty::Request> request,
+      std::shared_ptr<std_srvs::srv::Empty::Response> response);
+
+  /**
+   * @brief Service callback leaving the STANDBY state (motor on).
+   *
+   * @see handle_stop_motor()
+   */
+  void handle_start_motor(
+      const std::shared_ptr<rmw_request_id_t> request_header,
+      const std::shared_ptr<std_srvs::srv::Empty::Request> request,
+      std::shared_ptr<std_srvs::srv::Empty::Response> response);
 
   /**
    * @brief Publish LaserScan & PointCloud2 (if enabled) messages.
@@ -421,6 +450,12 @@ private:
   /// Handle for the dynamic parameter callback registration.
   OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 
+  /// Service putting the device into STANDBY (rplidar_ros compatible name).
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr stop_motor_service_;
+
+  /// Service leaving STANDBY (rplidar_ros compatible name).
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr start_motor_service_;
+
   /// Diagnostic updater instance used to report node and device health.
   diagnostic_updater::Updater diagnostic_updater_;
 
@@ -432,6 +467,9 @@ private:
 
   /// share fsm state across threads
   std::atomic<DriverState> current_state_{DriverState::CONNECTING};
+
+  /// Requested standby state, consumed by @ref scan_loop() on each iteration.
+  std::atomic<bool> standby_requested_{false};
 
   /// Mutex protecting access to the driver instance from multiple threads.
   std::mutex driver_mutex_;

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <depend>tf2_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>lifecycle_msgs</depend>
+  <depend>std_srvs</depend>
 
   <exec_depend>launch_ros</exec_depend>
 

--- a/param/rplidar.yaml
+++ b/param/rplidar.yaml
@@ -47,6 +47,20 @@ rplidar_node:
     #   supported freq from its datasheet.
     rpm: 0
 
+    # auto_standby:
+    #   false: The motor keeps spinning as long as the node is ACTIVE. Use the
+    #          'stop_motor' / 'start_motor' services to park it manually.
+    #   true : The motor is stopped automatically when the last subscriber of
+    #          the scan topic (and of the cloud topic, if publish_point_cloud
+    #          is enabled) disconnects, and restarts when one connects again.
+    #          The serial connection stays open, so waking up only costs the
+    #          motor spin-up time.
+    #
+    #          While enabled, the 'stop_motor' / 'start_motor' services are
+    #          rejected: the subscriber count is the only thing driving the
+    #          motor.
+    auto_standby: false
+
     # ---------------------------------------------------------
     # [Measurement Quality & Performance]
     # ---------------------------------------------------------

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -141,12 +141,12 @@ RPlidarNode::on_configure(const rclcpp_lifecycle::State &) {
   // ------------------------------------------------------------------------
   // 3b. Standby services
   // ------------------------------------------------------------------------
-  stop_motor_service_ = this->create_service<std_srvs::srv::Empty>(
+  stop_motor_service_ = this->create_service<std_srvs::srv::Trigger>(
       "stop_motor",
       std::bind(&RPlidarNode::handle_stop_motor, this, std::placeholders::_1,
                 std::placeholders::_2, std::placeholders::_3));
 
-  start_motor_service_ = this->create_service<std_srvs::srv::Empty>(
+  start_motor_service_ = this->create_service<std_srvs::srv::Trigger>(
       "start_motor",
       std::bind(&RPlidarNode::handle_start_motor, this, std::placeholders::_1,
                 std::placeholders::_2, std::placeholders::_3));
@@ -624,36 +624,68 @@ size_t RPlidarNode::count_output_subscribers() const {
   return subscribers;
 }
 
-void RPlidarNode::handle_stop_motor(
-    const std::shared_ptr<rmw_request_id_t>,
-    const std::shared_ptr<std_srvs::srv::Empty::Request>,
-    std::shared_ptr<std_srvs::srv::Empty::Response>) {
+bool RPlidarNode::standby_request_refused(
+    const char *service_name, std_srvs::srv::Trigger::Response &response) {
 
   if (auto_standby_enabled_.load()) {
-    RCLCPP_WARN(this->get_logger(),
-                "[Standby] Ignoring stop_motor request: 'auto_standby' is "
-                "enabled, the subscriber count controls the motor.");
+    response.success = false;
+    response.message = "Refused: 'auto_standby' is enabled, the subscriber "
+                       "count controls the motor.";
+  } else if (this->get_current_state().id() !=
+             lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+    // The scan loop applies the request, and it only runs while ACTIVE.
+    response.success = false;
+    response.message = "Refused: the node is not ACTIVE, so the scan loop "
+                       "cannot apply the request.";
+  } else {
+    return false;
+  }
+
+  RCLCPP_WARN(this->get_logger(), "[Standby] %s: %s", service_name,
+              response.message.c_str());
+  return true;
+}
+
+void RPlidarNode::handle_stop_motor(
+    const std::shared_ptr<rmw_request_id_t>,
+    const std::shared_ptr<std_srvs::srv::Trigger::Request>,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+
+  if (standby_request_refused("stop_motor", *response)) {
     return;
   }
 
-  RCLCPP_INFO(this->get_logger(), "[Standby] stop_motor requested.");
-  standby_requested_.store(true);
+  // The scan loop picks the flag up on its next iteration, so report that the
+  // request was accepted rather than that the motor has already stopped.
+  const bool was_requested = standby_requested_.exchange(true);
+
+  response->success = true;
+  response->message = was_requested
+                          ? "Standby had already been requested."
+                          : "Standby requested, the motor stops shortly.";
+
+  RCLCPP_INFO(this->get_logger(), "[Standby] stop_motor: %s",
+              response->message.c_str());
 }
 
 void RPlidarNode::handle_start_motor(
     const std::shared_ptr<rmw_request_id_t>,
-    const std::shared_ptr<std_srvs::srv::Empty::Request>,
-    std::shared_ptr<std_srvs::srv::Empty::Response>) {
+    const std::shared_ptr<std_srvs::srv::Trigger::Request>,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
 
-  if (auto_standby_enabled_.load()) {
-    RCLCPP_WARN(this->get_logger(),
-                "[Standby] Ignoring start_motor request: 'auto_standby' is "
-                "enabled, the subscriber count controls the motor.");
+  if (standby_request_refused("start_motor", *response)) {
     return;
   }
 
-  RCLCPP_INFO(this->get_logger(), "[Standby] start_motor requested.");
-  standby_requested_.store(false);
+  const bool was_requested = standby_requested_.exchange(false);
+
+  response->success = true;
+  response->message = was_requested
+                          ? "Wake-up requested, the motor restarts shortly."
+                          : "The driver was not in a requested standby.";
+
+  RCLCPP_INFO(this->get_logger(), "[Standby] start_motor: %s",
+              response->message.c_str());
 }
 
 // ============================================================================

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -238,7 +238,10 @@ RPlidarNode::on_activate(const rclcpp_lifecycle::State &state) {
   }
   // Activation always means "start scanning": a standby request issued during
   // a previous ACTIVE period must not survive the lifecycle transition.
+  // With 'auto_standby' the scan loop re-evaluates the subscriber count
+  // immediately anyway.
   standby_requested_ = false;
+  auto_standby_engaged_ = false;
 
   // Start scan loop thread.
   is_scanning_ = true;
@@ -318,6 +321,8 @@ void RPlidarNode::init_parameters() {
   init_param("publish_point_cloud", params_.publish_point_cloud);
   init_param("interpolated_rays", params_.interpolated_rays);
   init_param("computed_ray_count", params_.computed_ray_count);
+  init_param("auto_standby", params_.auto_standby);
+  auto_standby_enabled_.store(params_.auto_standby);
 }
 // ============================================================================
 // Scan Loop (Fault-Tolerant FSM)
@@ -332,13 +337,20 @@ void RPlidarNode::init_parameters() {
  *  - WARMUP       : Start motor and configure scan mode
  *  - RUNNING      : Continuously grab scan data and publish LaserScan
  *  - RESETTING    : Recreate driver instance to recover from persistent errors
- *  - STANDBY      : Motor stopped on user request, connection kept alive
+ *  - STANDBY      : Motor stopped (service request or 'auto_standby' with no
+ *                   subscribers), connection kept alive
  */
 void RPlidarNode::scan_loop() {
   // Initialize FSM state for this thread
   current_state_.store(DriverState::CONNECTING);
 
   int error_count = 0;
+
+  // Subscriber polling is throttled: the count only has to be accurate to
+  // within a fraction of a second, and this loop can spin very fast.
+  constexpr auto SUBSCRIBER_POLL_PERIOD = 200ms;
+  auto last_subscriber_poll =
+      std::chrono::steady_clock::now() - SUBSCRIBER_POLL_PERIOD;
 
   RCLCPP_INFO(this->get_logger(), "[FSM] Scan loop started.");
 
@@ -347,12 +359,40 @@ void RPlidarNode::scan_loop() {
     DriverState state = current_state_.load();
 
     // -----------------------------------------------------------------
+    // Auto standby: follow subscriber demand.
+    //
+    // Standby is only entered from RUNNING, so the device is always
+    // detected, health-checked and reported once before the motor is
+    // allowed to idle. Waking up is permitted from STANDBY at any time.
+    // -----------------------------------------------------------------
+    if (auto_standby_enabled_.load()) {
+      const auto now = std::chrono::steady_clock::now();
+      if (now - last_subscriber_poll >= SUBSCRIBER_POLL_PERIOD) {
+        last_subscriber_poll = now;
+        const size_t subscribers = count_output_subscribers();
+
+        if (subscribers == 0 && state == DriverState::RUNNING) {
+          RCLCPP_INFO(this->get_logger(),
+                      "[Standby] No subscribers left, going to standby.");
+          auto_standby_engaged_.store(true);
+        } else if (subscribers > 0 && auto_standby_engaged_.load()) {
+          RCLCPP_INFO(this->get_logger(),
+                      "[Standby] Subscriber connected, waking up.");
+          auto_standby_engaged_.store(false);
+        }
+      }
+    } else {
+      auto_standby_engaged_.store(false);
+    }
+
+    // -----------------------------------------------------------------
     // Standby requests are handled here, before the switch, so that they
     // take precedence over any transition the FSM is about to perform.
     // The service callbacks only set the flag; every state change stays
     // owned by this thread.
     // -----------------------------------------------------------------
-    const bool want_standby = standby_requested_.load();
+    const bool want_standby =
+        standby_requested_.load() || auto_standby_engaged_.load();
 
     if (want_standby && state != DriverState::STANDBY) {
       RCLCPP_INFO(this->get_logger(),
@@ -568,13 +608,33 @@ void RPlidarNode::scan_loop() {
 }
 
 // ============================================================================
-// Standby Services
+// Standby
 // ============================================================================
+
+size_t RPlidarNode::count_output_subscribers() const {
+  size_t subscribers = 0;
+
+  if (scan_pub_) {
+    subscribers += scan_pub_->get_subscription_count();
+  }
+  if (params_.publish_point_cloud && cloud_pub_) {
+    subscribers += cloud_pub_->get_subscription_count();
+  }
+
+  return subscribers;
+}
 
 void RPlidarNode::handle_stop_motor(
     const std::shared_ptr<rmw_request_id_t>,
     const std::shared_ptr<std_srvs::srv::Empty::Request>,
     std::shared_ptr<std_srvs::srv::Empty::Response>) {
+
+  if (auto_standby_enabled_.load()) {
+    RCLCPP_WARN(this->get_logger(),
+                "[Standby] Ignoring stop_motor request: 'auto_standby' is "
+                "enabled, the subscriber count controls the motor.");
+    return;
+  }
 
   RCLCPP_INFO(this->get_logger(), "[Standby] stop_motor requested.");
   standby_requested_.store(true);
@@ -584,6 +644,13 @@ void RPlidarNode::handle_start_motor(
     const std::shared_ptr<rmw_request_id_t>,
     const std::shared_ptr<std_srvs::srv::Empty::Request>,
     std::shared_ptr<std_srvs::srv::Empty::Response>) {
+
+  if (auto_standby_enabled_.load()) {
+    RCLCPP_WARN(this->get_logger(),
+                "[Standby] Ignoring start_motor request: 'auto_standby' is "
+                "enabled, the subscriber count controls the motor.");
+    return;
+  }
 
   RCLCPP_INFO(this->get_logger(), "[Standby] start_motor requested.");
   standby_requested_.store(false);
@@ -638,10 +705,15 @@ void RPlidarNode::update_diagnostics(
     stat.add("Connection", "Disconnected / Resetting");
     stat.add("Health Code", "Error");
   } else if (state == DriverState::STANDBY) {
+    // Spell out *why* the motor is off: "auto_standby with no subscribers"
+    // is the most common source of "my lidar does not spin" reports.
+    const bool auto_engaged = auto_standby_engaged_.load();
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK,
-                 "Standby (motor off)");
+                 auto_engaged ? "Standby (auto: no subscribers)"
+                              : "Standby (motor off)");
     stat.add("Connection", "Connected (Motor Stopped)");
     stat.add("Health Code", "OK (Standby)");
+    stat.add("Standby Trigger", auto_engaged ? "auto_standby" : "stop_motor");
   } else {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR,
                  "Unknown State");
@@ -653,6 +725,7 @@ void RPlidarNode::update_diagnostics(
   stat.add("Serial Port", params_.serial_port);
   stat.add("Target RPM", params_.rpm);
   stat.add("Device Info", cached_device_info_);
+  stat.add("Auto Standby", auto_standby_enabled_.load() ? "ON" : "OFF");
 }
 
 // ============================================================================
@@ -948,7 +1021,26 @@ rcl_interfaces::msg::SetParametersResult RPlidarNode::parameters_callback(
     }
 
     // --------------------------------------------------------------------
-    // Case 5: Scan mode change (requires motor restart)
+    // Case 5: Auto standby toggle
+    // --------------------------------------------------------------------
+    else if (param.get_name() == "auto_standby" &&
+             param.get_type() == rclcpp::ParameterType::PARAMETER_BOOL) {
+      params_.auto_standby = param.as_bool();
+      auto_standby_enabled_.store(params_.auto_standby);
+
+      // Turning it off must not leave the device parked in an automatic
+      // standby nobody can leave through the services.
+      if (!params_.auto_standby) {
+        auto_standby_engaged_.store(false);
+        standby_requested_.store(false);
+      }
+
+      RCLCPP_INFO(this->get_logger(), "[Dynamic] Auto standby: %s",
+                  params_.auto_standby ? "ON" : "OFF");
+    }
+
+    // --------------------------------------------------------------------
+    // Case 6: Scan mode change (requires motor restart)
     // --------------------------------------------------------------------
     else if (param.get_name() == "scan_mode" &&
              param.get_type() == rclcpp::ParameterType::PARAMETER_STRING) {
@@ -990,7 +1082,7 @@ rcl_interfaces::msg::SetParametersResult RPlidarNode::parameters_callback(
     }
 
     // --------------------------------------------------------------------
-    // Case 6: In ROS2, all parameters are configurable. Warn for unsupported
+    // Case 7: In ROS2, all parameters are configurable. Warn for unsupported
     // --------------------------------------------------------------------
     else {
       RCLCPP_WARN(

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -682,7 +682,7 @@ void RPlidarNode::handle_start_motor(
   response->success = true;
   response->message = was_requested
                           ? "Wake-up requested, the motor restarts shortly."
-                          : "The driver was not in a requested standby.";
+                          : "The driver was not in standby, nothing to do.";
 
   RCLCPP_INFO(this->get_logger(), "[Standby] start_motor: %s",
               response->message.c_str());

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -139,6 +139,19 @@ RPlidarNode::on_configure(const rclcpp_lifecycle::State &) {
       &RPlidarNode::parameters_callback, this, std::placeholders::_1));
 
   // ------------------------------------------------------------------------
+  // 3b. Standby services (names kept compatible with rplidar_ros)
+  // ------------------------------------------------------------------------
+  stop_motor_service_ = this->create_service<std_srvs::srv::Empty>(
+      "stop_motor",
+      std::bind(&RPlidarNode::handle_stop_motor, this, std::placeholders::_1,
+                std::placeholders::_2, std::placeholders::_3));
+
+  start_motor_service_ = this->create_service<std_srvs::srv::Empty>(
+      "start_motor",
+      std::bind(&RPlidarNode::handle_start_motor, this, std::placeholders::_1,
+                std::placeholders::_2, std::placeholders::_3));
+
+  // ------------------------------------------------------------------------
   // 4. QoS setup for LaserScan publisher
   // ------------------------------------------------------------------------
   std::string qos_policy;
@@ -223,6 +236,10 @@ RPlidarNode::on_activate(const rclcpp_lifecycle::State &state) {
   if (params_.publish_point_cloud) {
     cloud_pub_->on_activate();
   }
+  // Activation always means "start scanning": a standby request issued during
+  // a previous ACTIVE period must not survive the lifecycle transition.
+  standby_requested_ = false;
+
   // Start scan loop thread.
   is_scanning_ = true;
   scan_thread_ = std::thread(&RPlidarNode::scan_loop, this);
@@ -258,6 +275,9 @@ RPlidarNode::on_cleanup(const rclcpp_lifecycle::State &) {
 
   scan_pub_.reset();
   cloud_pub_.reset();
+
+  stop_motor_service_.reset();
+  start_motor_service_.reset();
 
   if (driver_) {
     driver_->disconnect();
@@ -312,6 +332,7 @@ void RPlidarNode::init_parameters() {
  *  - WARMUP       : Start motor and configure scan mode
  *  - RUNNING      : Continuously grab scan data and publish LaserScan
  *  - RESETTING    : Recreate driver instance to recover from persistent errors
+ *  - STANDBY      : Motor stopped on user request, connection kept alive
  */
 void RPlidarNode::scan_loop() {
   // Initialize FSM state for this thread
@@ -324,6 +345,37 @@ void RPlidarNode::scan_loop() {
   while (rclcpp::ok() && is_scanning_) {
     // Read current FSM state from atomic variable
     DriverState state = current_state_.load();
+
+    // -----------------------------------------------------------------
+    // Standby requests are handled here, before the switch, so that they
+    // take precedence over any transition the FSM is about to perform.
+    // The service callbacks only set the flag; every state change stays
+    // owned by this thread.
+    // -----------------------------------------------------------------
+    const bool want_standby = standby_requested_.load();
+
+    if (want_standby && state != DriverState::STANDBY) {
+      RCLCPP_INFO(this->get_logger(),
+                  "[FSM] Entering STANDBY (stopping motor)...");
+      {
+        std::lock_guard<std::mutex> lock(driver_mutex_);
+        if (driver_) {
+          driver_->stop_motor();
+        }
+        // The new-protocol rpm fixup must run again after the next start.
+        initial_reset_required_ = true;
+      }
+      error_count = 0;
+      state = DriverState::STANDBY;
+      current_state_.store(state);
+    } else if (!want_standby && state == DriverState::STANDBY) {
+      // Re-enter through CHECK_HEALTH: it validates the device and falls
+      // back to CONNECTING if it went away while we were idle.
+      RCLCPP_INFO(this->get_logger(),
+                  "[FSM] Leaving STANDBY (restarting motor)...");
+      state = DriverState::CHECK_HEALTH;
+      current_state_.store(state);
+    }
 
     switch (state) {
     // -----------------------------------------------------------------
@@ -494,6 +546,16 @@ void RPlidarNode::scan_loop() {
       error_count = 0;
       break;
     }
+
+    // -----------------------------------------------------------------
+    // State 6: STANDBY
+    // -----------------------------------------------------------------
+    // Motor is off and the connection is kept open. Nothing to do here:
+    // the loop is left through the standby handling above, and the tail
+    // sleep keeps CPU usage low.
+    case DriverState::STANDBY: {
+      break;
+    }
     }
 
     // Reduce CPU usage when not actively scanning
@@ -503,6 +565,28 @@ void RPlidarNode::scan_loop() {
   }
 
   RCLCPP_INFO(this->get_logger(), "[FSM] Scan loop terminated.");
+}
+
+// ============================================================================
+// Standby Services
+// ============================================================================
+
+void RPlidarNode::handle_stop_motor(
+    const std::shared_ptr<rmw_request_id_t>,
+    const std::shared_ptr<std_srvs::srv::Empty::Request>,
+    std::shared_ptr<std_srvs::srv::Empty::Response>) {
+
+  RCLCPP_INFO(this->get_logger(), "[Standby] stop_motor requested.");
+  standby_requested_.store(true);
+}
+
+void RPlidarNode::handle_start_motor(
+    const std::shared_ptr<rmw_request_id_t>,
+    const std::shared_ptr<std_srvs::srv::Empty::Request>,
+    std::shared_ptr<std_srvs::srv::Empty::Response>) {
+
+  RCLCPP_INFO(this->get_logger(), "[Standby] start_motor requested.");
+  standby_requested_.store(false);
 }
 
 // ============================================================================
@@ -553,6 +637,11 @@ void RPlidarNode::update_diagnostics(
                  "Hardware Error / Resetting");
     stat.add("Connection", "Disconnected / Resetting");
     stat.add("Health Code", "Error");
+  } else if (state == DriverState::STANDBY) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK,
+                 "Standby (motor off)");
+    stat.add("Connection", "Connected (Motor Stopped)");
+    stat.add("Health Code", "OK (Standby)");
   } else {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR,
                  "Unknown State");

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -139,7 +139,7 @@ RPlidarNode::on_configure(const rclcpp_lifecycle::State &) {
       &RPlidarNode::parameters_callback, this, std::placeholders::_1));
 
   // ------------------------------------------------------------------------
-  // 3b. Standby services (names kept compatible with rplidar_ros)
+  // 3b. Standby services
   // ------------------------------------------------------------------------
   stop_motor_service_ = this->create_service<std_srvs::srv::Empty>(
       "stop_motor",
@@ -705,8 +705,6 @@ void RPlidarNode::update_diagnostics(
     stat.add("Connection", "Disconnected / Resetting");
     stat.add("Health Code", "Error");
   } else if (state == DriverState::STANDBY) {
-    // Spell out *why* the motor is off: "auto_standby with no subscribers"
-    // is the most common source of "my lidar does not spin" reports.
     const bool auto_engaged = auto_standby_engaged_.load();
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK,
                  auto_engaged ? "Standby (auto: no subscribers)"

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -1055,15 +1055,20 @@ rcl_interfaces::msg::SetParametersResult RPlidarNode::parameters_callback(
     // --------------------------------------------------------------------
     else if (param.get_name() == "auto_standby" &&
              param.get_type() == rclcpp::ParameterType::PARAMETER_BOOL) {
-      params_.auto_standby = param.as_bool();
-      auto_standby_enabled_.store(params_.auto_standby);
-
-      // Turning it off must not leave the device parked in an automatic
-      // standby nobody can leave through the services.
-      if (!params_.auto_standby) {
-        auto_standby_engaged_.store(false);
-        standby_requested_.store(false);
+      const bool enabled = param.as_bool();
+      if (enabled == params_.auto_standby) {
+        continue; // No change.
       }
+      params_.auto_standby = enabled;
+      auto_standby_enabled_.store(enabled);
+
+      // Whichever owner takes over decides from scratch: the flag that is no
+      // longer authoritative must not latch, and handing the motor to
+      // 'auto_standby' while nobody listens must not cost a spin-up.
+      standby_requested_.store(false);
+      auto_standby_engaged_.store(
+          enabled && current_state_.load() == DriverState::STANDBY &&
+          count_output_subscribers() == 0);
 
       RCLCPP_INFO(this->get_logger(), "[Dynamic] Auto standby: %s",
                   params_.auto_standby ? "ON" : "OFF");

--- a/test/test_rplidar_node.cpp
+++ b/test/test_rplidar_node.cpp
@@ -440,3 +440,49 @@ TEST_F(RplidarNodeTest, AutoStandbyIgnoresStopMotorService) {
   node->trigger_transition(
       rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE));
 }
+
+/**
+ * @brief [Behavioral Test] Standby request outside the ACTIVE state
+ * The scan loop is what applies a standby request, and it only runs while the
+ * node is ACTIVE. A request arriving in INACTIVE must therefore be refused
+ * instead of being recorded into a flag nobody will ever read.
+ */
+TEST_F(RplidarNodeTest, StandbyServiceRefusedWhileInactive) {
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("dummy_mode", true);
+
+  auto node = std::make_shared<rplidar_driver::RPlidarNode>(options);
+  auto client_node = std::make_shared<rclcpp::Node>("standby_inactive_client");
+
+  // Configure only: the services are created in on_configure, but the scan
+  // loop is not started until on_activate.
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE));
+  ASSERT_EQ(node->get_current_state().id(), State::PRIMARY_STATE_INACTIVE);
+
+  auto stop_client =
+      client_node->create_client<std_srvs::srv::Trigger>("stop_motor");
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.add_node(client_node);
+
+  ASSERT_TRUE(stop_client->wait_for_service(std::chrono::seconds(3)))
+      << "'stop_motor' must be reachable in the INACTIVE state.";
+
+  auto future = stop_client->async_send_request(
+      std::make_shared<std_srvs::srv::Trigger::Request>());
+  ASSERT_EQ(
+      executor.spin_until_future_complete(future, std::chrono::seconds(3)),
+      rclcpp::FutureReturnCode::SUCCESS);
+
+  auto response = future.get();
+  EXPECT_FALSE(response->success)
+      << "'stop_motor' must report failure while the node is not ACTIVE.";
+  EXPECT_NE(response->message.find("ACTIVE"), std::string::npos)
+      << "The refusal should name the reason. Got: " << response->message;
+
+  // Clean shutdown
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CLEANUP));
+}

--- a/test/test_rplidar_node.cpp
+++ b/test/test_rplidar_node.cpp
@@ -1,8 +1,10 @@
 #include <atomic>
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <future>
 #include <gtest/gtest.h>
 #include <lifecycle_msgs/msg/state.hpp>
 #include <lifecycle_msgs/msg/transition.hpp>
+#include <mutex>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
@@ -240,6 +242,181 @@ TEST_F(RplidarNodeTest, StandbyServiceTogglesScanning) {
   scan_count = 0;
   spin_for(std::chrono::seconds(2));
   EXPECT_GT(scan_count.load(), 0) << "Scans did not resume after start_motor.";
+
+  // Clean shutdown
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE));
+}
+
+/**
+ * @brief [Integration Test] Auto Standby
+ * Verifies that with 'auto_standby' enabled the motor follows the subscriber
+ * count: standby while nobody listens, scanning as soon as someone does.
+ *
+ * Standby is observed through '/diagnostics' rather than '/scan', since
+ * subscribing to the scan topic is exactly what wakes the device up.
+ */
+TEST_F(RplidarNodeTest, AutoStandbyFollowsSubscribers) {
+  // ==========================================================================
+  // [Arrange] Active node in dummy mode with auto_standby enabled
+  // ==========================================================================
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("dummy_mode", true);
+  options.append_parameter_override("auto_standby", true);
+  // Keep the diagnostics rate high enough for a short test.
+  options.append_parameter_override("diagnostic_updater.period", 0.2);
+
+  auto node = std::make_shared<rplidar_driver::RPlidarNode>(options);
+  auto client_node = std::make_shared<rclcpp::Node>("auto_standby_test_client");
+
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE));
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_ACTIVATE));
+
+  // Latest diagnostic summary for the driver status task.
+  std::string last_summary;
+  std::mutex summary_mutex;
+  auto diag_sub =
+      client_node->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+          "/diagnostics", 10,
+          [&](diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg) {
+            for (const auto &status : msg->status) {
+              if (status.name.find("RPLidar Status") != std::string::npos) {
+                std::lock_guard<std::mutex> lock(summary_mutex);
+                last_summary = status.message;
+              }
+            }
+          });
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.add_node(client_node);
+
+  auto spin_for = [&executor](std::chrono::milliseconds duration) {
+    const auto deadline = std::chrono::steady_clock::now() + duration;
+    while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
+      executor.spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  };
+
+  // Pump the executor until the diagnostics summary contains 'needle'.
+  auto wait_for_summary = [&](const std::string &needle,
+                              std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
+      executor.spin_some();
+      {
+        std::lock_guard<std::mutex> lock(summary_mutex);
+        if (last_summary.find(needle) != std::string::npos) {
+          return true;
+        }
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return false;
+  };
+
+  // ==========================================================================
+  // [Act & Assert] 1. Nobody subscribes -> the driver parks itself
+  // ==========================================================================
+  EXPECT_TRUE(wait_for_summary("Standby", std::chrono::seconds(5)))
+      << "Driver did not enter standby without subscribers. Last summary: '"
+      << last_summary << "'";
+
+  EXPECT_EQ(node->get_current_state().id(), State::PRIMARY_STATE_ACTIVE)
+      << "Auto standby must not leave the ACTIVE lifecycle state.";
+
+  // ==========================================================================
+  // [Act & Assert] 2. A subscriber connects -> scanning resumes
+  // ==========================================================================
+  std::atomic<int> scan_count{0};
+  auto scan_sub = client_node->create_subscription<sensor_msgs::msg::LaserScan>(
+      "scan", rclcpp::SensorDataQoS(),
+      [&scan_count](sensor_msgs::msg::LaserScan::SharedPtr) { scan_count++; });
+
+  spin_for(std::chrono::seconds(3));
+  EXPECT_GT(scan_count.load(), 0)
+      << "Scans did not resume after a subscriber connected.";
+  EXPECT_TRUE(wait_for_summary("Scanning", std::chrono::seconds(3)))
+      << "Diagnostics did not report scanning. Last summary: '" << last_summary
+      << "'";
+
+  // ==========================================================================
+  // [Act & Assert] 3. The subscriber leaves -> back to standby
+  // ==========================================================================
+  scan_sub.reset();
+
+  EXPECT_TRUE(wait_for_summary("Standby", std::chrono::seconds(5)))
+      << "Driver did not return to standby after the subscriber left. "
+      << "Last summary: '" << last_summary << "'";
+
+  scan_count = 0;
+  spin_for(std::chrono::milliseconds(500));
+  EXPECT_EQ(scan_count.load(), 0) << "Scans still published while in standby.";
+
+  // Clean shutdown
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE));
+}
+
+/**
+ * @brief [Behavioral Test] Auto Standby overrides the manual services
+ * Mirrors rplidar_ros: while 'auto_standby' is enabled, 'stop_motor' is
+ * ignored and the subscriber count stays in charge of the motor.
+ */
+TEST_F(RplidarNodeTest, AutoStandbyIgnoresStopMotorService) {
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("dummy_mode", true);
+  options.append_parameter_override("auto_standby", true);
+
+  auto node = std::make_shared<rplidar_driver::RPlidarNode>(options);
+  auto client_node = std::make_shared<rclcpp::Node>("auto_standby_svc_client");
+
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE));
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_ACTIVATE));
+
+  std::atomic<int> scan_count{0};
+  auto scan_sub = client_node->create_subscription<sensor_msgs::msg::LaserScan>(
+      "scan", rclcpp::SensorDataQoS(),
+      [&scan_count](sensor_msgs::msg::LaserScan::SharedPtr) { scan_count++; });
+
+  auto stop_client =
+      client_node->create_client<std_srvs::srv::Empty>("stop_motor");
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.add_node(client_node);
+
+  auto spin_for = [&executor](std::chrono::milliseconds duration) {
+    const auto deadline = std::chrono::steady_clock::now() + duration;
+    while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
+      executor.spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  };
+
+  // A subscriber is connected, so the device must be scanning.
+  spin_for(std::chrono::seconds(2));
+  ASSERT_GT(scan_count.load(), 0) << "No scans published with a subscriber.";
+
+  // The service call is accepted at the transport level, but ignored.
+  ASSERT_TRUE(stop_client->wait_for_service(std::chrono::seconds(3)));
+  auto future = stop_client->async_send_request(
+      std::make_shared<std_srvs::srv::Empty::Request>());
+  EXPECT_EQ(
+      executor.spin_until_future_complete(future, std::chrono::seconds(3)),
+      rclcpp::FutureReturnCode::SUCCESS);
+
+  spin_for(std::chrono::milliseconds(500));
+  scan_count = 0;
+  spin_for(std::chrono::milliseconds(500));
+
+  EXPECT_GT(scan_count.load(), 0)
+      << "'stop_motor' must be ignored while 'auto_standby' is enabled.";
 
   // Clean shutdown
   node->trigger_transition(

--- a/test/test_rplidar_node.cpp
+++ b/test/test_rplidar_node.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <future>
 #include <gtest/gtest.h>
 #include <lifecycle_msgs/msg/state.hpp>
@@ -5,6 +6,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
+#include <std_srvs/srv/empty.hpp>
 
 #include "rplidar_node.hpp"
 
@@ -147,6 +149,97 @@ TEST_F(RplidarNodeTest, ScanPublicationCheck) {
   // ==========================================================================
   EXPECT_TRUE(message_received)
       << "Timeout: Failed to receive /scan topic within 3 seconds.";
+
+  // Clean shutdown
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE));
+}
+
+/**
+ * @brief [Integration Test] Standby Mode
+ * Verifies that the 'stop_motor' service suspends scan publication without
+ * leaving the ACTIVE lifecycle state, and that 'start_motor' resumes it.
+ */
+TEST_F(RplidarNodeTest, StandbyServiceTogglesScanning) {
+  // ==========================================================================
+  // [Arrange] Active node in dummy mode + a client node for the services
+  // ==========================================================================
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("dummy_mode", true);
+
+  auto node = std::make_shared<rplidar_driver::RPlidarNode>(options);
+  auto client_node = std::make_shared<rclcpp::Node>("standby_test_client");
+
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE));
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_ACTIVATE));
+
+  std::atomic<int> scan_count{0};
+  auto sub = client_node->create_subscription<sensor_msgs::msg::LaserScan>(
+      "scan", rclcpp::SensorDataQoS(),
+      [&scan_count](sensor_msgs::msg::LaserScan::SharedPtr) { scan_count++; });
+
+  auto stop_client =
+      client_node->create_client<std_srvs::srv::Empty>("stop_motor");
+  auto start_client =
+      client_node->create_client<std_srvs::srv::Empty>("start_motor");
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.add_node(client_node);
+
+  // Spin for a fixed wall-clock duration, draining all pending callbacks.
+  auto spin_for = [&executor](std::chrono::milliseconds duration) {
+    const auto deadline = std::chrono::steady_clock::now() + duration;
+    while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
+      executor.spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  };
+
+  // Call a service and pump the executor until the response arrives.
+  auto call_service =
+      [&executor](rclcpp::Client<std_srvs::srv::Empty>::SharedPtr client) {
+        EXPECT_TRUE(client->wait_for_service(std::chrono::seconds(3)))
+            << "Service '" << client->get_service_name() << "' never appeared.";
+
+        auto future = client->async_send_request(
+            std::make_shared<std_srvs::srv::Empty::Request>());
+        return executor.spin_until_future_complete(future,
+                                                   std::chrono::seconds(3)) ==
+               rclcpp::FutureReturnCode::SUCCESS;
+      };
+
+  // ==========================================================================
+  // [Act & Assert] 1. Scanning is running before the standby request
+  // ==========================================================================
+  spin_for(std::chrono::milliseconds(500));
+  EXPECT_GT(scan_count.load(), 0) << "No scans published before standby.";
+
+  // ==========================================================================
+  // [Act & Assert] 2. stop_motor -> publication stops, node stays ACTIVE
+  // ==========================================================================
+  EXPECT_TRUE(call_service(stop_client)) << "'stop_motor' call timed out.";
+
+  // Let the scan thread observe the request and drain any in-flight message.
+  spin_for(std::chrono::milliseconds(300));
+
+  scan_count = 0;
+  spin_for(std::chrono::milliseconds(500));
+  EXPECT_EQ(scan_count.load(), 0) << "Scans still published while in standby.";
+
+  EXPECT_EQ(node->get_current_state().id(), State::PRIMARY_STATE_ACTIVE)
+      << "Standby must not leave the ACTIVE lifecycle state.";
+
+  // ==========================================================================
+  // [Act & Assert] 3. start_motor -> publication resumes
+  // ==========================================================================
+  EXPECT_TRUE(call_service(start_client)) << "'start_motor' call timed out.";
+
+  scan_count = 0;
+  spin_for(std::chrono::seconds(2));
+  EXPECT_GT(scan_count.load(), 0) << "Scans did not resume after start_motor.";
 
   // Clean shutdown
   node->trigger_transition(

--- a/test/test_rplidar_node.cpp
+++ b/test/test_rplidar_node.cpp
@@ -8,7 +8,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
-#include <std_srvs/srv/empty.hpp>
+#include <std_srvs/srv/trigger.hpp>
 
 #include "rplidar_node.hpp"
 
@@ -183,9 +183,9 @@ TEST_F(RplidarNodeTest, StandbyServiceTogglesScanning) {
       [&scan_count](sensor_msgs::msg::LaserScan::SharedPtr) { scan_count++; });
 
   auto stop_client =
-      client_node->create_client<std_srvs::srv::Empty>("stop_motor");
+      client_node->create_client<std_srvs::srv::Trigger>("stop_motor");
   auto start_client =
-      client_node->create_client<std_srvs::srv::Empty>("start_motor");
+      client_node->create_client<std_srvs::srv::Trigger>("start_motor");
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node->get_node_base_interface());
@@ -201,17 +201,21 @@ TEST_F(RplidarNodeTest, StandbyServiceTogglesScanning) {
   };
 
   // Call a service and pump the executor until the response arrives.
+  // Returns nullptr if the call timed out.
   auto call_service =
-      [&executor](rclcpp::Client<std_srvs::srv::Empty>::SharedPtr client) {
-        EXPECT_TRUE(client->wait_for_service(std::chrono::seconds(3)))
-            << "Service '" << client->get_service_name() << "' never appeared.";
+      [&executor](rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr client)
+      -> std_srvs::srv::Trigger::Response::SharedPtr {
+    EXPECT_TRUE(client->wait_for_service(std::chrono::seconds(3)))
+        << "Service '" << client->get_service_name() << "' never appeared.";
 
-        auto future = client->async_send_request(
-            std::make_shared<std_srvs::srv::Empty::Request>());
-        return executor.spin_until_future_complete(future,
-                                                   std::chrono::seconds(3)) ==
-               rclcpp::FutureReturnCode::SUCCESS;
-      };
+    auto future = client->async_send_request(
+        std::make_shared<std_srvs::srv::Trigger::Request>());
+    if (executor.spin_until_future_complete(future, std::chrono::seconds(3)) !=
+        rclcpp::FutureReturnCode::SUCCESS) {
+      return nullptr;
+    }
+    return future.get();
+  };
 
   // ==========================================================================
   // [Act & Assert] 1. Scanning is running before the standby request
@@ -222,7 +226,12 @@ TEST_F(RplidarNodeTest, StandbyServiceTogglesScanning) {
   // ==========================================================================
   // [Act & Assert] 2. stop_motor -> publication stops, node stays ACTIVE
   // ==========================================================================
-  EXPECT_TRUE(call_service(stop_client)) << "'stop_motor' call timed out.";
+  auto stop_response = call_service(stop_client);
+  ASSERT_NE(stop_response, nullptr) << "'stop_motor' call timed out.";
+  EXPECT_TRUE(stop_response->success)
+      << "'stop_motor' was refused: " << stop_response->message;
+  EXPECT_FALSE(stop_response->message.empty())
+      << "'stop_motor' must explain what it did.";
 
   // Let the scan thread observe the request and drain any in-flight message.
   spin_for(std::chrono::milliseconds(300));
@@ -237,7 +246,10 @@ TEST_F(RplidarNodeTest, StandbyServiceTogglesScanning) {
   // ==========================================================================
   // [Act & Assert] 3. start_motor -> publication resumes
   // ==========================================================================
-  EXPECT_TRUE(call_service(start_client)) << "'start_motor' call timed out.";
+  auto start_response = call_service(start_client);
+  ASSERT_NE(start_response, nullptr) << "'start_motor' call timed out.";
+  EXPECT_TRUE(start_response->success)
+      << "'start_motor' was refused: " << start_response->message;
 
   scan_count = 0;
   spin_for(std::chrono::seconds(2));
@@ -385,7 +397,7 @@ TEST_F(RplidarNodeTest, AutoStandbyIgnoresStopMotorService) {
       [&scan_count](sensor_msgs::msg::LaserScan::SharedPtr) { scan_count++; });
 
   auto stop_client =
-      client_node->create_client<std_srvs::srv::Empty>("stop_motor");
+      client_node->create_client<std_srvs::srv::Trigger>("stop_motor");
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node->get_node_base_interface());
@@ -403,13 +415,19 @@ TEST_F(RplidarNodeTest, AutoStandbyIgnoresStopMotorService) {
   spin_for(std::chrono::seconds(2));
   ASSERT_GT(scan_count.load(), 0) << "No scans published with a subscriber.";
 
-  // The service call is accepted at the transport level, but ignored.
+  // The call is served, but the request itself must be refused.
   ASSERT_TRUE(stop_client->wait_for_service(std::chrono::seconds(3)));
   auto future = stop_client->async_send_request(
-      std::make_shared<std_srvs::srv::Empty::Request>());
-  EXPECT_EQ(
+      std::make_shared<std_srvs::srv::Trigger::Request>());
+  ASSERT_EQ(
       executor.spin_until_future_complete(future, std::chrono::seconds(3)),
       rclcpp::FutureReturnCode::SUCCESS);
+
+  auto response = future.get();
+  EXPECT_FALSE(response->success)
+      << "'stop_motor' must report failure while 'auto_standby' is enabled.";
+  EXPECT_NE(response->message.find("auto_standby"), std::string::npos)
+      << "The refusal should name the reason. Got: " << response->message;
 
   spin_for(std::chrono::milliseconds(500));
   scan_count = 0;

--- a/test/test_rplidar_node.cpp
+++ b/test/test_rplidar_node.cpp
@@ -9,6 +9,8 @@
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <std_srvs/srv/trigger.hpp>
+#include <string>
+#include <vector>
 
 #include "rplidar_node.hpp"
 
@@ -485,4 +487,238 @@ TEST_F(RplidarNodeTest, StandbyServiceRefusedWhileInactive) {
   // Clean shutdown
   node->trigger_transition(
       rclcpp_lifecycle::Transition(Transition::TRANSITION_CLEANUP));
+}
+
+/**
+ * @brief [Behavioral Test] Enabling 'auto_standby' takes the motor over
+ * Toggling the parameter hands ownership of the motor to the subscriber count,
+ * so a standby left behind by 'stop_motor' must not survive the switch: with a
+ * subscriber connected, the device has to wake up again.
+ *
+ * Without the handover the driver would be stuck: the manual flag keeps it
+ * parked while 'start_motor' is refused for as long as 'auto_standby' is on.
+ *
+ * Setting the parameter to the value it already has must change nothing, which
+ * is checked first so that a wrongly cleared flag cannot pass as a success.
+ */
+TEST_F(RplidarNodeTest, AutoStandbyEnableClearsManualStandby) {
+  // ==========================================================================
+  // [Arrange] Active node in dummy mode, 'auto_standby' off, one subscriber
+  // ==========================================================================
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("dummy_mode", true);
+  options.append_parameter_override("auto_standby", false);
+
+  auto node = std::make_shared<rplidar_driver::RPlidarNode>(options);
+  auto client_node = std::make_shared<rclcpp::Node>("standby_handover_client");
+
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE));
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_ACTIVATE));
+
+  std::atomic<int> scan_count{0};
+  auto scan_sub = client_node->create_subscription<sensor_msgs::msg::LaserScan>(
+      "scan", rclcpp::SensorDataQoS(),
+      [&scan_count](sensor_msgs::msg::LaserScan::SharedPtr) { scan_count++; });
+
+  auto stop_client =
+      client_node->create_client<std_srvs::srv::Trigger>("stop_motor");
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.add_node(client_node);
+
+  auto spin_for = [&executor](std::chrono::milliseconds duration) {
+    const auto deadline = std::chrono::steady_clock::now() + duration;
+    while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
+      executor.spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  };
+
+  // Pump the executor until scans arrive, or give up after 'timeout'.
+  auto wait_for_scans = [&](std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
+      executor.spin_some();
+      if (scan_count.load() > 0) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return false;
+  };
+
+  ASSERT_TRUE(wait_for_scans(std::chrono::seconds(3)))
+      << "No scans published before the standby request.";
+
+  // ==========================================================================
+  // [Act & Assert] 1. 'stop_motor' parks the device
+  // ==========================================================================
+  ASSERT_TRUE(stop_client->wait_for_service(std::chrono::seconds(3)));
+  auto future = stop_client->async_send_request(
+      std::make_shared<std_srvs::srv::Trigger::Request>());
+  ASSERT_EQ(
+      executor.spin_until_future_complete(future, std::chrono::seconds(3)),
+      rclcpp::FutureReturnCode::SUCCESS);
+  ASSERT_TRUE(future.get()->success) << "'stop_motor' was refused.";
+
+  spin_for(std::chrono::milliseconds(500));
+  scan_count = 0;
+  spin_for(std::chrono::milliseconds(500));
+  ASSERT_EQ(scan_count.load(), 0) << "Scans still published after stop_motor.";
+
+  // ==========================================================================
+  // [Act & Assert] 2. Re-setting the parameter to 'false' is a no-op
+  // ==========================================================================
+  auto unchanged = node->set_parameter(rclcpp::Parameter("auto_standby", false));
+  EXPECT_TRUE(unchanged.successful) << unchanged.reason;
+
+  scan_count = 0;
+  spin_for(std::chrono::seconds(1));
+  EXPECT_EQ(scan_count.load(), 0)
+      << "Setting 'auto_standby' to its current value must not wake the motor.";
+
+  // ==========================================================================
+  // [Act & Assert] 3. Enabling 'auto_standby' hands the motor to the demand
+  // ==========================================================================
+  auto enabled = node->set_parameter(rclcpp::Parameter("auto_standby", true));
+  ASSERT_TRUE(enabled.successful) << enabled.reason;
+
+  scan_count = 0;
+  EXPECT_TRUE(wait_for_scans(std::chrono::seconds(5)))
+      << "The driver stayed parked after 'auto_standby' was enabled, even "
+      << "though a subscriber is connected.";
+
+  // Clean shutdown
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE));
+}
+
+/**
+ * @brief [Behavioral Test] The handover costs no spin-up
+ * Same handover as above, but without a subscriber: the motor must stay off.
+ * Waking up only to park again one poll later would spin the motor for
+ * nothing, so the driver is watched through '/diagnostics' for the whole
+ * settling window instead of only at the end.
+ */
+TEST_F(RplidarNodeTest, AutoStandbyEnableKeepsMotorParkedWithoutSubscribers) {
+  // ==========================================================================
+  // [Arrange] Active node in dummy mode, nobody subscribing to 'scan'
+  // ==========================================================================
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("dummy_mode", true);
+  options.append_parameter_override("auto_standby", false);
+  // Sample fast enough to catch a short spin-up.
+  options.append_parameter_override("diagnostic_updater.period", 0.05);
+
+  auto node = std::make_shared<rplidar_driver::RPlidarNode>(options);
+  auto client_node = std::make_shared<rclcpp::Node>("standby_no_blip_client");
+
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE));
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_ACTIVATE));
+
+  // Every summary the driver status task reported, in order, without repeats.
+  std::vector<std::string> summaries;
+  std::mutex summary_mutex;
+  auto diag_sub =
+      client_node->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+          "/diagnostics", 10,
+          [&](diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg) {
+            for (const auto &status : msg->status) {
+              if (status.name.find("RPLidar Status") == std::string::npos) {
+                continue;
+              }
+              std::lock_guard<std::mutex> lock(summary_mutex);
+              if (summaries.empty() || summaries.back() != status.message) {
+                summaries.push_back(status.message);
+              }
+            }
+          });
+
+  auto stop_client =
+      client_node->create_client<std_srvs::srv::Trigger>("stop_motor");
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.add_node(client_node);
+
+  auto spin_for = [&executor](std::chrono::milliseconds duration) {
+    const auto deadline = std::chrono::steady_clock::now() + duration;
+    while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
+      executor.spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  };
+
+  auto last_summary = [&]() {
+    std::lock_guard<std::mutex> lock(summary_mutex);
+    return summaries.empty() ? std::string() : summaries.back();
+  };
+
+  // Pump the executor until the latest summary contains 'needle'.
+  auto wait_for_summary = [&](const std::string &needle,
+                              std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
+      executor.spin_some();
+      if (last_summary().find(needle) != std::string::npos) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return false;
+  };
+
+  ASSERT_TRUE(wait_for_summary("Scanning", std::chrono::seconds(5)))
+      << "Driver never reached the scanning state. Last summary: '"
+      << last_summary() << "'";
+
+  // ==========================================================================
+  // [Act & Assert] 1. 'stop_motor' parks the device
+  // ==========================================================================
+  ASSERT_TRUE(stop_client->wait_for_service(std::chrono::seconds(3)));
+  auto future = stop_client->async_send_request(
+      std::make_shared<std_srvs::srv::Trigger::Request>());
+  ASSERT_EQ(
+      executor.spin_until_future_complete(future, std::chrono::seconds(3)),
+      rclcpp::FutureReturnCode::SUCCESS);
+  ASSERT_TRUE(future.get()->success) << "'stop_motor' was refused.";
+
+  ASSERT_TRUE(wait_for_summary("Standby (motor off)", std::chrono::seconds(5)))
+      << "Driver did not park on request. Last summary: '" << last_summary()
+      << "'";
+
+  // ==========================================================================
+  // [Act & Assert] 2. Enabling 'auto_standby' must not restart the motor
+  // ==========================================================================
+  {
+    std::lock_guard<std::mutex> lock(summary_mutex);
+    summaries.clear();
+  }
+
+  auto enabled = node->set_parameter(rclcpp::Parameter("auto_standby", true));
+  ASSERT_TRUE(enabled.successful) << enabled.reason;
+
+  spin_for(std::chrono::seconds(2));
+
+  std::lock_guard<std::mutex> lock(summary_mutex);
+  for (const auto &summary : summaries) {
+    EXPECT_EQ(summary.find("Scanning"), std::string::npos)
+        << "The motor was restarted during the handover: '" << summary << "'";
+    EXPECT_EQ(summary.find("Warming Up"), std::string::npos)
+        << "The motor was restarted during the handover: '" << summary << "'";
+  }
+
+  ASSERT_FALSE(summaries.empty()) << "No diagnostics seen after the handover.";
+  EXPECT_NE(summaries.back().find("auto: no subscribers"), std::string::npos)
+      << "'auto_standby' should own the standby once it is enabled. Got: '"
+      << summaries.back() << "'";
+
+  // Clean shutdown
+  node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE));
 }


### PR DESCRIPTION
## Summary

Adds a standby mode to the driver: the motor can be parked without leaving the
ACTIVE lifecycle state, either on request through two services or automatically
based on subscriber demand.

Until now the only way to stop the motor was `on_deactivate`, which joins the
scan thread and tears down the publishers -- far more than "stop spinning for a
while", and it takes a full reconnect to come back. Standby keeps the serial
connection, the scan thread and the publishers alive, so waking up only costs
the motor spin-up time.

## Behaviour

**Services.** `stop_motor` parks the device, `start_motor` wakes it. The node
stays in `PRIMARY_STATE_ACTIVE` throughout.

```bash
ros2 service call /stop_motor std_srvs/srv/Trigger
ros2 service call /start_motor std_srvs/srv/Trigger
```

The response reports whether the request was **accepted**, with the reason in
`message` when it was not. A request is refused when `auto_standby` owns the
motor, or when the node is not ACTIVE and the scan loop that applies the
request is therefore not running.

**`auto_standby`.** When enabled, the subscriber count owns the motor: the
device parks itself once the last consumer of `scan` disconnects and spins up
again when one appears. Cloud subscribers are counted too when
`publish_point_cloud` is enabled, so a cloud-only consumer keeps the device
awake. While it is enabled the two services are rejected -- same precedence as
rplidar_ros -- so there is a single source of truth for the motor state.

**Diagnostics.** Standby is reported as `OK` rather than falling through to
`Unknown State`, and distinguishes `Standby (auto: no subscribers)` from
`Standby (motor off)`. "Nobody is subscribed" is the likely answer to "why is
my lidar not spinning", so it seemed worth saying out loud.

## Design decisions worth a look

**The standby request is consumed by the scan thread, not the service
callback.** Service callbacks run on the executor thread and only set an
atomic flag; every FSM transition stays owned by `scan_loop()`. Flipping
`current_state_` from the callback would be data-race-safe but state-machine
racy: a request landing mid-`WARMUP` gets clobbered when `WARMUP` stores
`RUNNING`, and the motor silently spins back up.

**Auto standby only engages from `RUNNING`.** The device is therefore always
connected, detected, health-checked and reported once before the motor is
allowed to idle. The cost is one spin-up at activation when nothing is
subscribed; the benefit is that auto standby never races the reconnection FSM
and device info is always cached for diagnostics. rplidar_ros effectively does
the same thing, since its check lives in the post-init loop.

**Waking goes through `CHECK_HEALTH`, not straight to `WARMUP`.** If the device
was unplugged while idle, `CHECK_HEALTH` falls back to `CONNECTING` and the
existing fault-tolerant recovery takes over.

**Subscriber polling is throttled to 200 ms.** The scan loop can spin very
fast; the count does not need that resolution.

**`success` means accepted, not completed.** The scan loop applies the request
on its next iteration, so the messages say "the motor stops shortly" rather
than claiming it already has. Blocking the callback until the transition
finished would stall the single-threaded executor the component registers for
a whole motor spin-up, and indefinitely if the device is unplugged.

## Compatibility

- Default behaviour is unchanged: `auto_standby` defaults to `false` and no
  service call is needed for the driver to work exactly as before.
- New build dependency on `std_srvs` (`package.xml` + `CMakeLists.txt`).
- No changes to `LidarDriverInterface` -- `start_motor()` / `stop_motor()`
  already existed, and `RealLidarDriver::stop_motor()` already did
  `stop()` + `setMotorSpeed(0)`, which is exactly what rplidar_ros does.

## Testing

- 4 new gtest cases, all in `dummy_mode` so CI needs no hardware:
  - `StandbyServiceTogglesScanning` -- publication stops on `stop_motor`,
    the node stays ACTIVE, publication resumes on `start_motor`.
  - `AutoStandbyFollowsSubscribers` -- parks with no subscribers, wakes on
    subscribe, parks again on unsubscribe. Observed via `/diagnostics`, since
    subscribing to `/scan` is exactly what wakes the device.
  - `AutoStandbyIgnoresStopMotorService` -- asserts the refusal directly on
    the response, rather than inferring it from the scans that keep arriving.
  - `StandbyServiceRefusedWhileInactive` -- covers the refusal outside the
    ACTIVE state, and pins that the services stay reachable there.
- Full suite green locally on Jazzy (73 tests, 0 failures).
- **Verified on real hardware (RPLIDAR S3)**: the `stop_motor` / `start_motor`
  services, `auto_standby` following the subscriber count, and unplugging the
  device while it sat in standby -- all behaved as described above.
- Not built locally on Humble / Lyrical / Rolling; relying on CI for those.
- Note: `ament_cmake_cppcheck` self-skips on cppcheck 2.13.0 ("performance
  issues"), so CI legs with a different version are its first real run.

## Docs

- README: new "Standby (Motor Control)" section covering both entry points and
  the diagnostics strings.
- `doc/rplidar_driver_sequence.md`: standby round trip added to the sequence
  diagram.

## AI tool disclosure

Per the OSRF Policy on the Use of Generative Tools in Contributions and the
disclosure section of the README, the same statement carried by each commit in
this PR:

Generated-by: Anthropic Claude (Claude Opus 5)

The source, tests and documentation in this PR were drafted with that tool and
then reviewed, built and verified on real hardware (RPLIDAR S3) by me before
submission.
